### PR TITLE
fix documentation for Kernel::System::Email::SendExecute(): the param…

### DIFF
--- a/Kernel/System/Email.pm
+++ b/Kernel/System/Email.pm
@@ -695,7 +695,16 @@ Really send the mail
 
     my $Result = $SendObject->SendExecute(
         From                   => $RealFrom,
-        ToArray                => \@ToArray,
+        To                     => \@ToArray,
+        Header                 => \$Param{Header},
+        Body                   => \$Param{Body},
+        CommunicationLogObject => $CommunicationLogObject,
+    );
+
+    # or
+    my $Result = $SendObject->SendExecute(
+        From                   => $RealFrom,
+        To                     => $To, # can be a string with comma separated mail addresses
         Header                 => \$Param{Header},
         Body                   => \$Param{Body},
         CommunicationLogObject => $CommunicationLogObject,


### PR DESCRIPTION
…eter 'ToArray' isn't used in the sub, the parameter 'To' is needed instead

From the perl module:

```perl
    # Check for required data
    for my $Needed (qw(To Header Body)) {
        if ( !$Param{$Needed} ) {
            return {
                Success      => 0,
                ErrorMessage => "Need $Needed!",
            };
        }
    }

    # Normalize 'To', always use an arrayref.
    my $To = $Param{'To'};
    if ( !( ref $To ) ) {
        $To = [ split( ',', $To, ) ];
    }
```