### PR TITLE
Fix double encoding for dynamic field filters in ticket overviews

### DIFF
--- a/Kernel/Output/HTML/Dashboard/TicketGeneric.pm
+++ b/Kernel/Output/HTML/Dashboard/TicketGeneric.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 maxence business consulting GmbH, http://www.maxence.de
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/Output/HTML/Dashboard/TicketGeneric.pm
+++ b/Kernel/Output/HTML/Dashboard/TicketGeneric.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 maxence business consulting GmbH, http://www.maxence.de
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -2186,15 +2187,10 @@ sub _ColumnFilterJSON {
 
         my %Values = %{ $Param{ColumnValues} };
 
-        # Keys must be link encoded for dynamic fields because they are added to URL during filtering
-        # and can contain characters like '&', ';', etc.
-        # See bug#14497 - https://bugs.otrs.org/show_bug.cgi?id=14497.
-        my $Encoding = ( $Param{ColumnName} =~ m/^DynamicField_/ ) ? 1 : 0;
-
         # Set possible values.
         for my $ValueKey ( sort { lc $Values{$a} cmp lc $Values{$b} } keys %Values ) {
             push @{$Data}, {
-                Key   => $Encoding ? $LayoutObject->LinkEncode($ValueKey) : $ValueKey,
+                Key   => $ValueKey,
                 Value => $Values{$ValueKey}
             };
         }

--- a/Kernel/Output/HTML/TicketOverview/Small.pm
+++ b/Kernel/Output/HTML/TicketOverview/Small.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 maxence business consulting GmbH, http://www.maxence.de
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -2032,15 +2033,10 @@ sub _ColumnFilterJSON {
 
         my %Values = %{ $Param{ColumnValues} };
 
-        # Keys must be link encoded for dynamic fields because they are added to URL during filtering
-        # and can contain characters like '&', ';', etc.
-        # See bug#14497 - https://bugs.otrs.org/show_bug.cgi?id=14497.
-        my $Encoding = ( $Param{ColumnName} =~ m/^DynamicField_/ ) ? 1 : 0;
-
         # Set possible values.
         for my $ValueKey ( sort { lc $Values{$a} cmp lc $Values{$b} } keys %Values ) {
             push @{$Data}, {
-                Key   => $Encoding ? $LayoutObject->LinkEncode($ValueKey) : $ValueKey,
+                Key   => $ValueKey,
                 Value => $Values{$ValueKey},
             };
         }

--- a/Kernel/Output/HTML/TicketOverview/Small.pm
+++ b/Kernel/Output/HTML/TicketOverview/Small.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 maxence business consulting GmbH, http://www.maxence.de
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/scripts/test/Selenium/Output/Dashboard/TicketGenericFilter.t
+++ b/scripts/test/Selenium/Output/Dashboard/TicketGenericFilter.t
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 maxence business consulting GmbH, http://www.maxence.de
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -20,6 +21,7 @@ $Selenium->RunTest(
 
         my $Helper       = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
         my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
+        my $DynamicFieldObject = $Kernel::OM->Get('Kernel::System::DynamicField');
 
         # Create test user.
         my $TestUserLogin = $Helper->TestUserCreate(
@@ -33,23 +35,69 @@ $Selenium->RunTest(
 
         my @Tests = (
             {
-                TN           => $TicketObject->TicketCreateNumber(),
-                CustomerUser => $Helper->GetRandomID() . '@first.com',
+                TN                => $TicketObject->TicketCreateNumber(),
+                CustomerUser      => $Helper->GetRandomID() . '@first.com',
+                DynamicFieldValue => 'Key',
             },
             {
-                TN           => $TicketObject->TicketCreateNumber(),
-                CustomerUser => $Helper->GetRandomID() . '@second.com',
+                TN                => $TicketObject->TicketCreateNumber(),
+                CustomerUser      => $Helper->GetRandomID() . '@second.com',
+                DynamicFieldValue => 'Key::Sub',
             },
             {
-                TN           => $TicketObject->TicketCreateNumber(),
-                CustomerUser => $Helper->GetRandomID() . '@third.com',
-                CustomerID   => 'CustomerCompany' . $Helper->GetRandomID() . '(#)',
+                TN                => $TicketObject->TicketCreateNumber(),
+                CustomerUser      => $Helper->GetRandomID() . '@third.com',
+                CustomerID        => 'CustomerCompany' . $Helper->GetRandomID() . '(#)',
+                DynamicFieldValue => 'Key;Special',
             },
             {
-                TN           => $TicketObject->TicketCreateNumber(),
-                CustomerUser => $Helper->GetRandomID() . '@fourth.com',
-                CustomerID   => 'CustomerCompany#%' . $Helper->GetRandomID() . '(#)',
+                TN                => $TicketObject->TicketCreateNumber(),
+                CustomerUser      => $Helper->GetRandomID() . '@fourth.com',
+                CustomerID        => 'CustomerCompany#%' . $Helper->GetRandomID() . '(#)',
             },
+        );
+
+        # Check if test dynamic field exists in the system, remove it if it does.
+        my $DynamicFieldName = 'DynamicFieldFilterTest';
+        my $DynamicField = $DynamicFieldObject->DynamicFieldGet(
+            Name => $DynamicFieldName,
+        );
+        my $Success;
+        if ( $DynamicField->{ID} ) {
+            my $ValuesDeleteSuccess = $Kernel::OM->Get('Kernel::System::DynamicFieldValue')->AllValuesDelete(
+                FieldID => $DynamicField->{ID},
+                UserID  => 1,
+            );
+            $Success = $DynamicFieldObject->DynamicFieldDelete(
+                ID     => $DynamicField->{ID},
+                UserID => 1,
+            );
+            $Self->True(
+                $Success,
+                "DynamicFieldID $DynamicField->{ID} is deleted",
+            );
+        }
+
+        # Create test dynamic field.
+        my $DynamicFieldID   = $DynamicFieldObject->DynamicFieldAdd(
+            Name       => $DynamicFieldName,
+            Label      => $DynamicFieldName,
+            FieldOrder => 9991,
+            FieldType  => 'Dropdown',
+            ObjectType => 'Ticket',
+            Config     => {
+                PossibleValues => {
+                    'Key'         => 'Value',
+                    'Key::Sub'    => 'SubValue',
+                    'Key;Special' => 'SpecialValue',
+                },
+            },
+            ValidID => 1,
+            UserID  => 1,
+        );
+        $Self->True(
+            $DynamicFieldID,
+            "DynamicFieldID $DynamicFieldID is created",
         );
 
         # Create test tickets.
@@ -72,11 +120,31 @@ $Selenium->RunTest(
                 "Ticket ID $TicketID - created"
             );
 
+            # Set dynamic field value for the ticket
+            if (defined $Test->{DynamicFieldValue}){
+                $Success = $Kernel::OM->Get('Kernel::System::DynamicFieldValue')->ValueSet(
+                    FieldID    => $DynamicFieldID,
+                    ObjectType => 'Ticket',
+                    ObjectID   => $TicketID,
+                    Value      => [
+                        {
+                            ValueText => $Test->{DynamicFieldValue},
+                        },
+                    ],
+                    UserID => 1,
+                );
+                $Self->True(
+                    $Success,
+                    "DynamicFieldID $DynamicFieldID is set to '$Test->{DynamicFieldValue}' successfully",
+                );
+            }
+
             push @Tickets, {
-                TicketID     => $TicketID,
-                TN           => $Test->{TN},
-                CustomerUser => $Test->{CustomerUser},
-                CustomerID   => $Test->{CustomerID}
+                TicketID          => $TicketID,
+                TN                => $Test->{TN},
+                CustomerUser      => $Test->{CustomerUser},
+                CustomerID        => $Test->{CustomerID},
+                DynamicFieldValue => $Test->{DynamicFieldValue},
             };
         }
 
@@ -378,6 +446,203 @@ $Selenium->RunTest(
                 index( $Selenium->get_page_source(), $Tickets[3]->{TN} ) > -1,
                 "Test ticket with TN $Tickets[3]->{TN} - found on screen after filtering with customer - $Tickets[3]->{CustomerID}",
             );
+
+            # Cleanup
+            $Selenium->WaitFor(
+                JavaScript =>
+                    "return typeof(\$) === 'function' && \$('a#Dashboard0120-TicketNew-remove-filters').length == 1;"
+            );
+
+            # Delete filter
+            $Selenium->execute_script(
+                "\$('a#Dashboard0120-TicketNew-remove-filters').trigger('click');"
+            );
+
+            # Wait for AJAX to finish.
+            $Selenium->WaitFor(
+                JavaScript =>
+                    'return typeof($) === "function" && !$("#Dashboard0120-TicketNew-box.Loading").length'
+            );
+        }
+
+        # Update configuration.
+        $Config                                     = $ConfigObject->Get('DashboardBackend')->{'0120-TicketNew'};
+        $Config->{DefaultColumns}->{CustomerUserID} = '0';
+        $Config->{DefaultColumns}->{CustomerID}     = '0';
+        $Config->{DefaultColumns}->{"DynamicField_$DynamicFieldName"} = '2';
+        $Helper->ConfigSettingChange(
+            Valid => 1,
+            Key   => 'DashboardBackend###0120-TicketNew',
+            Value => $Config,
+        );
+
+        # Refresh dashboard screen and clean it's cache.
+        $Kernel::OM->Get('Kernel::System::Cache')->CleanUp(
+            Type => 'Dashboard',
+        );
+
+        $Selenium->VerifiedRefresh();
+
+        # Navigate to dashboard screen.
+        $Selenium->VerifiedGet("${ScriptAlias}index.pl?");
+
+        # Check if '$DynamicFieldName' filter for TicketNew dashboard is set.
+        eval {
+            $Self->True(
+                $Selenium->find_element("//a[contains(\@title, \'$DynamicFieldName\' )]"),
+                "'$DynamicFieldName' filter for TicketNew dashboard is set",
+            );
+        };
+        if ($@) {
+            $Self->True(
+                $@,
+                "'$DynamicFieldName' filter for TicketNew dashboard is not set",
+            );
+        }
+        else {
+
+            # Click on column setting filter for the dynamic field in TicketNew generic dashboard overview.
+            $Selenium->find_element("//a[contains(\@title, \'$DynamicFieldName\' )]")->click();
+
+            # Wait for option to exist
+            $Selenium->WaitFor(
+                JavaScript =>
+                    "return typeof(\$) === \"function\" && \$('#ColumnFilterDynamicField_${DynamicFieldName}0120-TicketNew > option[value=\"$Tickets[0]->{DynamicFieldValue}\"]').length"
+            );
+
+            # Choose the value.
+            $Selenium->execute_script(
+                "\$('#ColumnFilterDynamicField_${DynamicFieldName}0120-TicketNew').val('$Tickets[0]->{DynamicFieldValue}').trigger('change');"
+            );
+            # Wait for AJAX to finish.
+            $Selenium->WaitFor(
+                JavaScript =>
+                    'return typeof($) === "function" && !$("#Dashboard0120-TicketNew-box.Loading").length'
+            );
+
+            # Verify the first test ticket is found by filtering with the first dynamic field value.
+            $Self->True(
+                index( $Selenium->get_page_source(), $Tickets[0]->{TN} ) > -1,
+                "Test ticket with TN $Tickets[0]->{TN} - found on screen after filtering with dynamic field value - $Tickets[0]->{DynamicFieldValue}",
+            );
+
+            # Verify the second test ticket is not found by filtering with the first dynamic field value.
+            $Self->True(
+                index( $Selenium->get_page_source(), $Tickets[1]->{TN} ) == -1,
+                "Test ticket with TN $Tickets[1]->{TN} - not found on screen after filtering with dynamic field value - $Tickets[0]->{DynamicFieldValue}",
+            );
+
+            # Verify the third test ticket is not found by filtering with the first dynamic field value.
+            $Self->True(
+                index( $Selenium->get_page_source(), $Tickets[2]->{TN} ) == -1,
+                "Test ticket with TN $Tickets[2]->{TN} - not found on screen after filtering with dynamic field value - $Tickets[0]->{DynamicFieldValue}",
+            );
+
+            # Cleanup
+            $Selenium->execute_script(
+                "\$('a#Dashboard0120-TicketNew-remove-filters').trigger('click');"
+            );
+            # Wait for AJAX to finish.
+            $Selenium->WaitFor(
+                JavaScript =>
+                    'return typeof($) === "function" && !$("#Dashboard0120-TicketNew-box.Loading").length'
+            );
+
+            # Verify if dynamic field values containing tree seperators (::) are filtered correctly.
+            $Selenium->find_element("//a[contains(\@title, \'$DynamicFieldName\' )]")->click();
+
+            # Wait for option to exist
+            $Selenium->WaitFor(
+                JavaScript =>
+                    "return typeof(\$) === \"function\" && \$('#ColumnFilterDynamicField_${DynamicFieldName}0120-TicketNew > option[value=\"$Tickets[1]->{DynamicFieldValue}\"]').length"
+            );
+
+            # Choose the value.
+            $Selenium->execute_script(
+                "\$('#ColumnFilterDynamicField_${DynamicFieldName}0120-TicketNew').val('$Tickets[1]->{DynamicFieldValue}').trigger('change');"
+            );
+
+            # Wait for AJAX to finish.
+            $Selenium->WaitFor(
+                JavaScript =>
+                    'return typeof($) === "function" && !$("#Dashboard0120-TicketNew-box.Loading").length'
+            );
+
+            # Verify the second test ticket is found by filtering with the second dynamic field value.
+            $Self->True(
+                index( $Selenium->get_page_source(), $Tickets[1]->{TN} ) > -1,
+                "Test ticket with TN $Tickets[1]->{TN} - found on screen after filtering with dynamic field value with special characters - $Tickets[1]->{DynamicFieldValue}",
+            );
+
+            # Verify the first test ticket is not found by filtering with the second dynamic field value.
+            $Self->True(
+                index( $Selenium->get_page_source(), $Tickets[0]->{TN} ) == -1,
+                "Test ticket with TN $Tickets[0]->{TN} - not found on screen after filtering with dynamic field value with special characters - $Tickets[1]->{DynamicFieldValue}",
+            );
+
+            # Verify the third test ticket is not found by filtering with the second dynamic field value.
+            $Self->True(
+                index( $Selenium->get_page_source(), $Tickets[2]->{TN} ) == -1,
+                "Test ticket with TN $Tickets[2]->{TN} - not found on screen after filtering with dynamic field value with special characters - $Tickets[1]->{DynamicFieldValue}",
+            );
+
+            # Cleanup
+            $Selenium->execute_script(
+                "\$('a#Dashboard0120-TicketNew-remove-filters').trigger('click');"
+            );
+            # Wait for AJAX to finish.
+            $Selenium->WaitFor(
+                JavaScript =>
+                    'return typeof($) === "function" && !$("#Dashboard0120-TicketNew-box.Loading").length'
+            );
+
+            # Verify if dynamic field values containing special characters is filtered correctly. See bug#14497.
+            $Selenium->find_element("//a[contains(\@title, \'$DynamicFieldName\' )]")->click();
+
+            # Wait for option to exist
+            $Selenium->WaitFor(
+                JavaScript =>
+                    "return typeof(\$) === \"function\" && \$('#ColumnFilterDynamicField_${DynamicFieldName}0120-TicketNew > option[value=\"$Tickets[2]->{DynamicFieldValue}\"]').length"
+            );
+
+            # Choose the value.
+            $Selenium->execute_script(
+                "\$('#ColumnFilterDynamicField_${DynamicFieldName}0120-TicketNew').val('$Tickets[2]->{DynamicFieldValue}').trigger('change');"
+            );
+
+            # Wait for AJAX to finish.
+            $Selenium->WaitFor(
+                JavaScript =>
+                    'return typeof($) === "function" && !$("#Dashboard0120-TicketNew-box.Loading").length'
+            );
+
+            # Verify the third test ticket is found by filtering with the third dynamic field value.
+            $Self->True(
+                index( $Selenium->get_page_source(), $Tickets[2]->{TN} ) > -1,
+                "Test ticket with TN $Tickets[2]->{TN} - found on screen after filtering with dynamic field value with special characters - $Tickets[2]->{DynamicFieldValue}",
+            );
+
+            # Verify the first test ticket is not found by filtering with the third dynamic field value.
+            $Self->True(
+                index( $Selenium->get_page_source(), $Tickets[0]->{TN} ) == -1,
+                "Test ticket with TN $Tickets[0]->{TN} - not found on screen after filtering with dynamic field value with special characters - $Tickets[2]->{DynamicFieldValue}",
+            );
+
+            # Verify the second test ticket is not found by filtering with the third dynamic field value.
+            $Self->True(
+                index( $Selenium->get_page_source(), $Tickets[1]->{TN} ) == -1,
+                "Test ticket with TN $Tickets[1]->{TN} - not found on screen after filtering with dynamic field value with special characters - $Tickets[2]->{DynamicFieldValue}",
+            );
+
+            # Cleanup
+            $Selenium->execute_script(
+                "\$('a#Dashboard0120-TicketNew-remove-filters').trigger('click');"
+            );
+            # Wait for AJAX to finish.
+            $Selenium->WaitFor(
+                JavaScript =>
+                    'return typeof($) === "function" && !$("#Dashboard0120-TicketNew-box.Loading").length'
+            );
         }
 
         # Delete test tickets.
@@ -400,6 +665,16 @@ $Selenium->RunTest(
                 "Ticket ID $Ticket->{TicketID} - deleted"
             );
         }
+
+        # Delete dynamic field
+        $Success = $DynamicFieldObject->DynamicFieldDelete(
+            ID     => $DynamicFieldID,
+            UserID => 1,
+        );
+        $Self->True(
+            $Success,
+            "DynamicFieldID $DynamicFieldID is deleted",
+        );
 
         # Make sure cache is correct.
         $Kernel::OM->Get('Kernel::System::Cache')->CleanUp(

--- a/scripts/test/Selenium/Output/Dashboard/TicketGenericFilter.t
+++ b/scripts/test/Selenium/Output/Dashboard/TicketGenericFilter.t
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 maxence business consulting GmbH, http://www.maxence.de
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/scripts/test/Selenium/Output/Ticket/OverviewSmall.t
+++ b/scripts/test/Selenium/Output/Ticket/OverviewSmall.t
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 maxence business consulting GmbH, http://www.maxence.de
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/scripts/test/Selenium/Output/Ticket/OverviewSmall.t
+++ b/scripts/test/Selenium/Output/Ticket/OverviewSmall.t
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 maxence business consulting GmbH, http://www.maxence.de
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -127,24 +128,27 @@ $Selenium->RunTest(
             push @TicketNumbers, $TicketNumber;
         }
 
-        # Reverse sort test ticket numbers for test purposes.
-        my @SortTicketNumbers = reverse sort @TicketNumbers;
-
         # Define every possible dynamic field value to at least one ticket.
         my @Tests = (
             {
-                Key      => 'Key1&1',
-                TicketID => $TicketIDs[0],
+                Key          => 'Key1&1',
+                TicketID     => $TicketIDs[0],
+                TicketNumber => $TicketNumbers[0],
             },
             {
-                Key      => 'Key2;2',
-                TicketID => $TicketIDs[1],
+                Key          => 'Key2;2',
+                TicketID     => $TicketIDs[1],
+                TicketNumber => $TicketNumbers[1],
             },
             {
-                Key      => 'Key3?3',
-                TicketID => $TicketIDs[2],
+                Key          => 'Key3?3',
+                TicketID     => $TicketIDs[2],
+                TicketNumber => $TicketNumbers[2],
             },
         );
+
+        # Reverse sort test ticket numbers for test purposes.
+        my @SortTicketNumbers = reverse sort @TicketNumbers;
 
         # Add dropdown dynamic field where keys have special characters like '&', ';' and '?'.
         my $DFName         = 'DF' . $RandomID;
@@ -228,45 +232,50 @@ $Selenium->RunTest(
 
         my $ScriptAlias = $Kernel::OM->Get('Kernel::Config')->Get('ScriptAlias');
 
-        # Check on AgentDashboard screen if the filter has correct keys from test dynamic field (see bug#14497).
-        $Selenium->find_element("//a[contains(\@title, \'$DFName, filter not active\' )]")->click();
+        # Go to status open view, overview small, default sort is Age, default order is Down and remove all filter
+        $Selenium->VerifiedGet("${ScriptAlias}index.pl?Action=AgentTicketStatusView;DeleteFilters=DeleteFilters");
+        $Selenium->VerifiedRefresh();
 
+        # Check the filter for dynamic fields on the AgentTicketStatusView screen (see bug#14497).
         for my $Test (@Tests) {
-            my $LinkEncodedKey = $LayoutObject->LinkEncode( $Test->{Key} );
+            # Open filter selection
+            $Selenium->find_element("//a[contains(\@title, \'$DFName, filter not active\' )]")->click();
 
             $Selenium->WaitFor(
                 JavaScript =>
-                    "return typeof(\$) === 'function' && \$('#ColumnFilterDynamicField_${DFName}0120-TicketNew option[value=\"$LinkEncodedKey\"]').length;"
+                    "return typeof(\$) === 'function' && \$('#ColumnFilterDynamicField_$DFName option[value=\"$Test->{Key}\"]').length;"
             );
 
-            $Self->True(
-                $Selenium->execute_script(
-                    "return \$('#ColumnFilterDynamicField_${DFName}0120-TicketNew option[value=\"$LinkEncodedKey\"]').length;"
-                ),
-                "Key '$Test->{Key}' is found as correctly encoded - '$LinkEncodedKey'"
+            $Selenium->InputFieldValueSet(
+                Element => "#ColumnFilterDynamicField_$DFName",
+                Value   => $Test->{Key},
             );
-        }
-
-        # Go to status open view, overview small, default sort is Age, default order is Down.
-        $Selenium->VerifiedGet("${ScriptAlias}index.pl?Action=AgentTicketStatusView");
-
-        # Check on AgentTicketStatusView screen if the filter has correct keys from test dynamic field (see bug#14497).
-        $Selenium->find_element("//a[contains(\@title, \'$DFName, filter not active\' )]")->click();
-
-        for my $Test (@Tests) {
-            my $LinkEncodedKey = $LayoutObject->LinkEncode( $Test->{Key} );
 
             $Selenium->WaitFor(
-                JavaScript =>
-                    "return typeof(\$) === 'function' && \$('#ColumnFilterDynamicField_$DFName option[value=\"$LinkEncodedKey\"]').length;"
+                JavaScript => "return typeof(\$) === 'function' && \$('li.ContextSettings.RemoveFilters').length;"
             );
 
+            # Verify the test ticket is found by filtering with the dynamic field key.
             $Self->True(
-                $Selenium->execute_script(
-                    "return \$('#ColumnFilterDynamicField_$DFName option[value=\"$LinkEncodedKey\"]').length;"
-                ),
-                "Key '$Test->{Key}' is found as correctly encoded - '$LinkEncodedKey'"
+                index( $Selenium->get_page_source(), $Test->{TicketNumber} ) > -1,
+                "Test ticket with Ticket# $Test->{TicketNumber} - found on screen after filtering with dynamic field key with special characters - $Test->{Key}.",
             );
+
+            # Check not matching for the other two tickets
+            OTHERTESTS:
+            for my $OtherTests (@Tests){
+                next OTHERTESTS if $OtherTests == $Test;
+
+                # Verify the other test ticket is not found by filtering with the dynamic field key of one ticket.
+                $Self->True(
+                    index( $Selenium->get_page_source(), $OtherTests->{TicketNumber} ) == -1,
+                    "Test ticket with Ticket# $OtherTests->{TicketNumber} - not found on screen after filtering with dynamic field key with special characters - $Test->{Key}.",
+                );
+            }
+
+            # Go to status open view, overview small, default sort is Age, default order is Down and remove all filter
+            $Selenium->VerifiedGet("${ScriptAlias}index.pl?Action=AgentTicketStatusView;DeleteFilters=DeleteFilters");
+            $Selenium->VerifiedRefresh();
         }
 
         # Set filter to test queue.


### PR DESCRIPTION
<!--
  You are amazing! 🚀
  Thanks for contributing to the Znuny community project!
  Please, DO NOT DELETE ANY TEXT from this template (unless instructed)!
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why this pull request should be accepted. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Dynamic field keys as filter values are encoded twice. Therefore it is not possible to filter for tree components from select fields (e.g. Main::Sub).

This was a bug before (bug#[14497](https://bugs.otrs.org/show_bug.cgi?id=14497)) and was fixed in ce5980f183d4c363ad03571629478d94c6a71b5b. A second fix for another bug (bug#[14982](https://bugs.otrs.org/show_bug.cgi?id=14982)) (not encoded CustomerID) in ecfeb7aa300eac654f9d0eafaa2d3b80214607d5 broke the first fix by encoding the key in the frontend, while the first fix already encoded the dynamic field values in the backend (e.g. "Main::Sub" -> "Main%3A%3ASub" -> "Main%253A%253ASub").

Since the later fix also works on the first bug, the first fix can be removed.

## Type of change
<!--
  What type of change does your PR introduce to Znuny?
  NOTE: Please check only 1 box '✖️'!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster for the code review.
-->

-  🆙 - Dependency upgrade (e.g. libraries) <!-- delete [ ] if not checked -->
- [x] 🐞 - Bugfix (non-breaking change which fixes an issue) <!-- delete [ ] if not checked -->
- [x] 💎 - Code quality improvements to existing code or addition of unit tests <!-- delete [ ] if not checked -->
-  🚀 - New feature (which adds functionality to an existing integration) <!-- delete [ ] if not checked -->

## Additional information
<!--
  Details are important and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  Note: Remove this section if not needed.
-->

To replicate the error:
 - Create a dynamic field (type dropdown) and create the keys "Main" and "Main::Sub".
 - Create a Ticket and add the dynamic field value with the key "Main::Sub".
 - Add the dynamic field to the setting `DashboardBackend###0120-TicketNew`.
 - Go to the dashboard widget "New Tickets" and select the matching value for the key "Main::Sub"
Expected result: the created ticket is shown.
Current result: no ticket is shown.

The same is true for the actions using TicketOverview/Small.pm, like AgentTicketQueue and AgentTicketStatusView.

<!--
- This PR is related to issue: #
- This PR fixes issue: #
- ...
-->

## Checklist
<!--
  Put an '✖️' in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  ❕ - nice to have
  ❗ - required before review
-->

- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [x] You improved or added new unit tests.(❕)
- [x] Local ZnunyCodePolicy run passes successfully.(❕)
- [x] Local unit tests pass.(❕)
- [x] GitHub workflow ZnunyCodePolicy passes.(❗)
- [x] GitHub workflow unit tests pass.(❗)

<!--
  Thank you for contributing ❤️

  Znuny @znuny/znuny
-->
