### PR TITLE
Fix visual minor - missing spacing when adding new values.

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AdminDynamicFieldDropdown.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminDynamicFieldDropdown.tt
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 maxence business consulting GmbH, http://www.maxence.de
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -203,6 +204,7 @@
                                 <div id="ValueServerError" class="TooltipErrorMessage"><p>[% Translate("This field is required.") | html %]</p></div>
 
                                 <a href="#" id="RemoveValue_[% Data.ValueCounter | html %]" class="RemoveButton ValueRemove"><i class="fa fa-minus-square-o"></i><span class="InvisibleText">[% Translate("Remove value") | html %]</span></a>
+                                <div class="SpacingTopMini" ></div>
                             </div>
 [% RenderBlockEnd("ValueTemplate") %]
                             <input type="hidden" name="DeletedValue" value="[% Data.DeletedString | html %]" id="DeletedValue" class="DeletedValue" />

--- a/Kernel/Output/HTML/Templates/Standard/AdminGenericInterfaceMappingXSLT.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminGenericInterfaceMappingXSLT.tt
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 maxence business consulting GmbH, http://www.maxence.de
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -266,6 +267,7 @@
                                 <input name="[% Data.Type | html %]Value_[% Data.ValueCounter | html %]" id="[% Data.Type | html %]Value" class="W20pc" type="text" maxlength="100" value="[% Data.Value | html %]"/>
 
                                 <a href="#" id="[% Data.Type | html %]RemoveValue_[% Data.ValueCounter | html %]" class="RemoveButton ValueRemove"><i class="fa fa-minus-square-o"></i><span class="InvisibleText">[% Translate("Remove regex") | html %]</span></a>
+                                <div class="SpacingTopMini" ></div>
                             </div>
 [% RenderBlockEnd("ValueTemplate") %]
                             <input type="hidden" name="[% Data.Type | html %]DeletedValue" value="[% Data.DeletedString | html %]" id="[% Data.Type | html %]DeletedValue" class="[% Data.Type | html %]DeletedValue" />


### PR DESCRIPTION
<!--
  You are amazing! 🚀
  Thanks for contributing to the Znuny community project!
  Please, DO NOT DELETE ANY TEXT from this template (unless instructed)!
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why this pull request should be accepted. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The templates to add new values to dynamic fields of the type 'Dropdown' and for XSLT mapping for the generic interface are missing a spacer that exists for saved values.
If new values are added to existing ones, from the second new value on, all new values will be closer to the previous on.

![image](https://user-images.githubusercontent.com/80031303/114391552-ecca9b00-9b97-11eb-9b11-8bd12cc6bd07.png)

This PR adds the missing spacer

## Type of change
<!--
  What type of change does your PR introduce to Znuny?
  NOTE: Please check only 1 box '✖️'!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster for the code review.
-->

- [x] 🐞 - Bugfix (non-breaking change which fixes an issue) <!-- delete [ ] if not checked -->

## Additional information
<!--
  Details are important and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  Note: Remove this section if not needed.
-->

To reproduce (dynamic field):
- Create a new dynamic field of type 'Dropdown'.
- Add two values.
- Save the dynamic field.
- Add two more values.
- The last one is closer to the previous one then the other ones.

To reproduce (XSLT mapping):
- Create a new Webservice.
- Select "HTTP::REST" as network transport on "OTRS as provider" and save.
- Select any operation.
- Select XLST for mapping ans save.
- Click on "configure" next to the mapping input
- Add values under "Data key regex filters (before mapping)" and "Data key regex filters (after mapping)"
- Add some XLST stylesheet 
`<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
  <xsl:output method="text"/>
</xsl:stylesheet>`
- Click save.
- Add two more values.
- The last one is closer to the previous one then the other ones.


<!--
- This PR is related to issue: #
- This PR fixes issue: #
- ...
-->

## Checklist
<!--
  Put an '✖️' in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  ❕ - nice to have
  ❗ - required before review
-->

- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [ ] Local ZnunyCodePolicy run passes successfully.(❕)
- [ ] Local unit tests pass.(❕)
- [x] GitHub workflow ZnunyCodePolicy passes.(❗)
- [x] GitHub workflow unit tests pass.(❗)

<!--
  Thank you for contributing ❤️

  Znuny @znuny/znuny
-->
