### PR TITLE
Fixed uninitialized value in pattern match warning for the TicketCreate operation (#55).

### DIFF
--- a/Kernel/GenericInterface/Operation/Ticket/TicketCreate.pm
+++ b/Kernel/GenericInterface/Operation/Ticket/TicketCreate.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 maxence business consulting GmbH, http://www.maxence.de
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -1462,7 +1463,11 @@ sub _TicketCreate {
 
     # Convert article body to plain text, if HTML content was supplied. This is necessary since auto response code
     #   expects plain text content. Please see bug#13397 for more information.
-    if ( $Article->{ContentType} =~ /text\/html/i || $Article->{MimeType} =~ /text\/html/i ) {
+    if (
+        ($Article->{ContentType} && $Article->{ContentType} =~ /text\/html/i)
+        || ($Article->{MimeType} && $Article->{MimeType} =~ /text\/html/i)
+        )
+    {
         $PlainBody = $Kernel::OM->Get('Kernel::System::HTMLUtils')->ToAscii(
             String => $Article->{Body},
         );


### PR DESCRIPTION
<!--
  You are amazing! 🚀
  Thanks for contributing to the Znuny community project!
  Please, DO NOT DELETE ANY TEXT from this template (unless instructed)!
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why this pull request should be accepted. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
TicketCreate expects ContentType or (MimeType and Charset). 
At some point there is a regex match that tries to match on ContentType and MimeType, which results in a "Use of uninitialized value in pattern match" warning for the parameter, that is not used.
This change only tries the match if a value exists.

## Type of change
<!--
  What type of change does your PR introduce to Znuny?
  NOTE: Please check only 1 box '✖️'!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster for the code review.
-->

- [x] 💎 - Code quality improvements to existing code or addition of unit tests 

## Additional information
<!--
  Details are important and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  Note: Remove this section if not needed.
-->
To replicate, create a webservice with the operation TicketCreate.
Create a ticket via REST with only ContentType or (MimeType and Charset).
This will create the warning in the apache error log.

<!--
- This PR is related to issue: #
- This PR fixes issue: #
- ...
-->

## Checklist
<!--
  Put an '✖️' in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  ❕ - nice to have
  ❗ - required before review
-->

- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [ ] Local ZnunyCodePolicy run passes successfully.(❕)
- [ ] Local unit tests pass.(❕)
- [x] GitHub workflow ZnunyCodePolicy passes.(❗)
- [x] GitHub workflow unit tests pass.(❗)

<!--
  Thank you for contributing ❤️

  Znuny @znuny/znuny
-->
