### PR TITLE
Redundant article search index rebuilding fixed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# 6.0.35 2021-xx-xx
+ - 2021-04-22 Fixed article search index redundant update on every article create.
+
 # 6.0.34 2021-04-21
  - 2021-04-14 Updated jquery-validate from version 1.16.0 to 1.19.3 (CVE-2021-21252).
  - 2021-04-13 Fixed product URL in HTTP Headers. Thanks to Renée Bäcker (@reneeb) [#42](https://github.com/znuny/Znuny/pull/42)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,3 @@
-# 6.0.35 2021-xx-xx
- - 2021-04-22 Fixed article search index redundant update on every article create.
-
 # 6.0.34 2021-04-21
  - 2021-04-14 Updated jquery-validate from version 1.16.0 to 1.19.3 (CVE-2021-21252).
  - 2021-04-13 Fixed product URL in HTTP Headers. Thanks to Renée Bäcker (@reneeb) [#42](https://github.com/znuny/Znuny/pull/42)

--- a/Kernel/System/Console/Command/Maint/Ticket/FulltextIndexRebuildWorker.pm
+++ b/Kernel/System/Console/Command/Maint/Ticket/FulltextIndexRebuildWorker.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/System/Console/Command/Maint/Ticket/FulltextIndexRebuildWorker.pm
+++ b/Kernel/System/Console/Command/Maint/Ticket/FulltextIndexRebuildWorker.pm
@@ -180,6 +180,13 @@ sub ArticleIndexRebuild {
                         ArticleID => $ArticleID,
                         UserID    => 1,
                     );
+
+                    if ( $Success ) {
+                        $ArticleObject->ArticleSearchIndexRebuildFlagSet(
+                            ArticleIDs => [$ArticleID],
+                            Value      => 0,
+                        );
+                    }
                 }
                 else {
                     $Success = $ArticleObject->ArticleSearchIndexBuild(
@@ -187,6 +194,8 @@ sub ArticleIndexRebuild {
                         ArticleID => $ArticleID,
                         UserID    => 1,
                     );
+                    # ArticleSearchIndexBuild() removes rebuild flag on rebuilding
+                    # success, so no need to do it here.
                 }
 
                 if ( !$Success ) {

--- a/Kernel/System/Console/Command/Maint/Ticket/FulltextIndexRebuildWorker.pm
+++ b/Kernel/System/Console/Command/Maint/Ticket/FulltextIndexRebuildWorker.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -192,12 +193,6 @@ sub ArticleIndexRebuild {
                     $Kernel::OM->Get('Kernel::System::Log')->Log(
                         Priority => 'error',
                         Message  => "Could not rebuild index for ArticleID '$ArticleID'!"
-                    );
-                }
-                else {
-                    $ArticleObject->ArticleSearchIndexRebuildFlagSet(
-                        ArticleIDs => [$ArticleID],
-                        Value      => 0,
                     );
                 }
             }

--- a/Kernel/System/Ticket/Article.pm
+++ b/Kernel/System/Ticket/Article.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/System/Ticket/Article.pm
+++ b/Kernel/System/Ticket/Article.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -918,7 +919,27 @@ Returns:
 sub ArticleSearchIndexBuild {
     my ( $Self, %Param ) = @_;
 
-    return $Kernel::OM->Get( $Self->{ArticleSearchIndexModule} )->ArticleSearchIndexBuild(%Param);
+    for my $Needed (qw(ArticleID)) {
+        if ( !$Param{$Needed} ) {
+            $Kernel::OM->Get('Kernel::System::Log')->Log(
+                Priority => 'error',
+                Message  => "Need $Needed!"
+            );
+            return;
+        }
+    }
+
+    if ( $Kernel::OM->Get( $Self->{ArticleSearchIndexModule} )->ArticleSearchIndexBuild(%Param) ) {
+
+        # Unset articles search index rebuild flag after successfull rebuild.
+        $Self->ArticleSearchIndexRebuildFlagSet(
+             ArticleIDs => [$Param{ArticleID}],
+             Value      => 0,
+        );
+        return 1;
+    }
+
+    return;
 }
 
 =head2 ArticleSearchIndexDelete()


### PR DESCRIPTION
<!--
  You are amazing! 🚀
  Thanks for contributing to the Znuny community project!
  Please, DO NOT DELETE ANY TEXT from this template (unless instructed)!
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why this pull request should be accepted. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Article search index is rebuild twice:

(1) in ArticleCreate (ArticleSearchIndexBuild called)

and

(2) by FulltextIndexRebuildWorker.pm task called from otrs.Daemon
(because articles are created in article table with default value
in search_index_needs_rebuild column which is 1).

This is waste of resouces and may cause unnecessarry data
fragmentation in search index backends.

This mod resolves this issue by unflagging article for search
index rebuilding after successfull index rebuild.

To be considered for future versions (not included in this mod):
change article.search_index_needs_rebuild default value in DB
schema to 0 to avoid possible races with otrs.Daemon trying to
update article search index just after insert to article table
in ArticleCreate and before ArticleCreate calls
ArticleSearchIndexBuild.

Author-Change-Id: IB#1108194

## Type of change
<!--
  What type of change does your PR introduce to Znuny?
  NOTE: Please check only 1 box '✖️'!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster for the code review.
-->
Change in POD.

- 🆙 - Dependency upgrade (e.g. libraries)
- 🐞 - Bugfix (non-breaking change which fixes an issue)
- [X] 💎 - Code quality improvements to existing code or addition of unit tests
- 🚀 - New feature (which adds functionality to an existing integration)

## Checklist
<!--
  Put an '✖️' in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  ❕ - nice to have
  ❗ - required before review
-->

- [ ] The code change is tested and works locally.(❗)
- [ ] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [ ] Local ZnunyCodePolicy run passes successfully.(❕)
- [ ] Local unit tests pass.(❕)
- [ ] GitHub workflow ZnunyCodePolicy passes.(❗)
- [ ] GitHub workflow unit tests pass.(❗)

<!--
  Thank you for contributing ❤️

  Znuny @znuny/znuny
-->
