### PR TITLE
Changed autocomplete to 'new-password' (#64).

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AdminCustomerUser.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminCustomerUser.tt
@@ -279,7 +279,7 @@
 [% RenderBlockStart("Password") %]
                         <label for="[% Data.Name | html %]">[% Translate(Data.Label) | html %]:</label>
                         <div class="Field">
-                            <input id="[% Data.Name | html %]" type="password" name="[% Data.Name | html %]" class="W50pc" value="[% Data.SelectedID | html %]" autocomplete="off" />
+                            <input id="[% Data.Name | html %]" type="password" name="[% Data.Name | html %]" class="W50pc" value="[% Data.SelectedID | html %]" autocomplete="new-password" />
                             <div>[% Translate(Data.Key) | html %]</div>
                         </div>
                         <div class="Clear"></div>

--- a/Kernel/Output/HTML/Templates/Standard/AdminUser.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminUser.tt
@@ -217,7 +217,7 @@
                             [% Translate("Password") | html %]:
                         </label>
                         <div class="Field">
-                            <input type="password" name="UserPw" id="UserPw" value="" class="W50pc [% Data.UserPwInvalid | html %] " maxlength="100" autocomplete="off" />
+                            <input type="password" name="UserPw" id="UserPw" value="" class="W50pc [% Data.UserPwInvalid | html %] " maxlength="100" autocomplete="new-password" />
 [% RenderBlockStart("ShowPasswordHint") %]
                             <p class="FieldExplanation">
                                 [% Translate("Will be auto-generated if left empty.") | html %]


### PR DESCRIPTION
<!--
  You are amazing! 🚀
  Thanks for contributing to the Znuny community project!
  Please, DO NOT DELETE ANY TEXT from this template (unless instructed)!
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why this pull request should be accepted. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
> This signals more accurately to password managers that this is not a
> place to be putting in any existing passwords.
> 
> See: https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete

From PR https://github.com/OTRS/otrs/pull/2030 from @thijskh.
This fixes the problem in Google Chrome and Microsoft Edge which both auto-fill the password while creating a new user or customer user. 
An administrator might miss, that the auto-filled password field wasn't changed, or might think that this is the auto-generated password from OTRS, since it says under the field, that it will be auto-generated if left empty.

In any case, it is bothering me for years.

I call it a bug, because it fills the wrong password in pretty much every case.

## Type of change
<!--
## Type of change
  What type of change does your PR introduce to Znuny?
  NOTE: Please add only one label with a starting '1 - ' to this PR!
  If your PR requires multiple labels to be applied, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster for the code review.

- '1 - 🆙 dependency upgrade - Dependency upgrade (e.g. libraries)
- '1 - 🐞 bug 🐞'            - Bugfix (non-breaking change which fixes an issue)
- '1 - 💎 code quality'      - Code quality improvements to existing code or addition of unit tests
- '1 - 🚀 feature'           - New feature (which adds functionality to an existing integration)
- '1 - ...'

-->
1 - 🐞 bug 🐞

## Additional information
<!--
  Details are important and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  Note: Remove this section if not needed.

  If a PR is related to an issue, please use the 'Linked issues' function on the sidebar.
-->
Tested locally with:
- Chrome Version 89.0.4389.128
- FireFox 88.0
- Edge Version 90.0.818.42 
- IE 19041.928
<!--
- This PR is related to PR: #
- ...
-->
This PR is related to PR: #https://github.com/OTRS/otrs/pull/2030

## Checklist
<!--
  Put an '✖️' in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  ❕ - nice to have
  ❗ - required before review
-->

- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [ ] Local ZnunyCodePolicy run passes successfully.(❕)
- [ ] Local unit tests pass.(❕)
- [x] GitHub workflow ZnunyCodePolicy passes.(❗)
- [x] GitHub workflow unit tests pass.(❗)

<!--
  Thank you for contributing ❤

  Znuny @znuny/znuny
-->
