### PR TITLE
Fixed typo in variable "$SumRow"/"$SumCol" (#65).

### DIFF
--- a/Kernel/System/Stats.pm
+++ b/Kernel/System/Stats.pm
@@ -3568,7 +3568,7 @@ sub _ColumnAndRowTranslation {
 
         # Special handling if the sumfunction is used.
         my $SumColRef;
-        if ( $Param{StatRef}->{SumRow} ) {
+        if ( $Param{StatRef}->{SumCol} ) {
             $SumColRef = pop @HeadOld;
         }
 


### PR DESCRIPTION
Fixes "Use of uninitialized value $ColumnName in string ne at /opt/otrs-6.0.30/Kernel/System/Stats.pm line 3591" log message when executing Maint::Stats::Dashboard::Generate for specific statistics.
Otherwise last entry of the @HeadOld-array is "undef", generating the above error message, since "undef" is not "popped" from @HeadOld.

<!--
  You are amazing! 🚀
  Thanks for contributing to the Znuny community project!
  Please, DO NOT DELETE ANY TEXT from this template (unless instructed)!
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why this pull request should be accepted. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Changing "$SumRow" to "$SumCol" (line 3571)

## Type of change
<!--
## Type of change
  What type of change does your PR introduce to Znuny?
  NOTE: Please add only one label with a starting '1 - ' to this PR!
  If your PR requires multiple labels to be applied, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster for the code review.

- '1 - 🆙 dependency upgrade - Dependency upgrade (e.g. libraries)
- '1 - 🐞 bug 🐞'            - Bugfix (non-breaking change which fixes an issue)
- '1 - 💎 code quality'      - Code quality improvements to existing code or addition of unit tests
- '1 - 🚀 feature'           - New feature (which adds functionality to an existing integration)
- '1 - ...'

-->
1 - 🐞 bug 🐞

## Additional information
<!--
  Details are important and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  Note: Remove this section if not needed.

  If a PR is related to an issue, please use the 'Linked issues' function on the sidebar.
-->
Message is not logged for every generated statistic, just in specific cases, when using sum-function.

<!--
- This PR is related to PR: #
- ...
-->

## Checklist
<!--
  Put an '✖️' in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  ❕ - nice to have
  ❗ - required before review
-->

- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [ ] Local ZnunyCodePolicy run passes successfully.(❕)
- [ ] Local unit tests pass.(❕)
- [x] GitHub workflow ZnunyCodePolicy passes.(❗)
- [x] GitHub workflow unit tests pass.(❗)

<!--
  Thank you for contributing ❤

  Znuny @znuny/znuny
-->
