### PR TITLE
Added ExternalFQDN parameter for better security.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,3 @@
-# 6.0.35 2021-xx-xx
- - 2021-05-11 ExtFQDN parameter added to allow avoiding internal FQDN revealing.
-
 # 6.0.34 2021-04-21
  - 2021-04-14 Updated jquery-validate from version 1.16.0 to 1.19.3 (CVE-2021-21252).
  - 2021-04-13 Fixed product URL in HTTP Headers. Thanks to Renée Bäcker (@reneeb) [#42](https://github.com/znuny/Znuny/pull/42)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# 6.0.35 2021-xx-xx
+ - 2021-05-11 ExtFQDN parameter added to allow avoiding internal FQDN revealing.
+
 # 6.0.34 2021-04-21
  - 2021-04-14 Updated jquery-validate from version 1.16.0 to 1.19.3 (CVE-2021-21252).
  - 2021-04-13 Fixed product URL in HTTP Headers. Thanks to Renée Bäcker (@reneeb) [#42](https://github.com/znuny/Znuny/pull/42)

--- a/Kernel/Config/Files/XML/Framework.xml
+++ b/Kernel/Config/Files/XML/Framework.xml
@@ -67,6 +67,13 @@
             <Item ValueType="String" ValueRegex="">yourhost.example.com</Item>
         </Value>
     </Setting>
+    <Setting Name="ExtFQDN" Required="0" Valid="0" ConfigLevel="200">
+        <Description Translatable="1">Defines the fully qualified domain name for external IDs generation (i.e. Message-ID, ContentID).</Description>
+        <Navigation>Core</Navigation>
+        <Value>
+            <Item ValueType="String" ValueRegex="">yourexternaldomain.example.com</Item>
+        </Value>
+    </Setting>
     <Setting Name="SupportDataCollector::HTTPHostname" Required="0" Valid="0" ConfigLevel="200">
         <Description Translatable="1">Defines the HTTP hostname for the support data collection with the public module 'PublicSupportDataCollector' (e.g. used from the OTRS Daemon).</Description>
         <Navigation>Core::SupportDataCollector</Navigation>

--- a/Kernel/Config/Files/XML/Framework.xml
+++ b/Kernel/Config/Files/XML/Framework.xml
@@ -67,7 +67,7 @@
             <Item ValueType="String" ValueRegex="">yourhost.example.com</Item>
         </Value>
     </Setting>
-    <Setting Name="ExtFQDN" Required="0" Valid="0" ConfigLevel="200">
+    <Setting Name="ExternalFQDN" Required="0" Valid="0" ConfigLevel="200">
         <Description Translatable="1">Defines the fully qualified domain name for external IDs generation (i.e. Message-ID, ContentID).</Description>
         <Navigation>Core</Navigation>
         <Value>

--- a/Kernel/System/Calendar/Appointment.pm
+++ b/Kernel/System/Calendar/Appointment.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/System/Calendar/Appointment.pm
+++ b/Kernel/System/Calendar/Appointment.pm
@@ -1646,12 +1646,12 @@ sub GetUniqueID {
     $StartTimeStrg =~ s/[-:]//g;
     $StartTimeStrg =~ s/\s/T/;
 
-    # get system ExtFQDN
+    # get system ExternalFQDN
     my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
-    my $ExtFQDN = $ConfigObject->Get('ExtFQDN') || $ConfigObject->Get('FQDN');
+    my $ExternalFQDN = $ConfigObject->Get('ExternalFQDN') || $ConfigObject->Get('FQDN');
 
     # return UniqueID
-    return "$StartTimeStrg-$Hash\@$ExtFQDN";
+    return "$StartTimeStrg-$Hash\@$ExternalFQDN";
 }
 
 =head2 AppointmentUpcomingGet()

--- a/Kernel/System/Calendar/Appointment.pm
+++ b/Kernel/System/Calendar/Appointment.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -1646,11 +1647,12 @@ sub GetUniqueID {
     $StartTimeStrg =~ s/[-:]//g;
     $StartTimeStrg =~ s/\s/T/;
 
-    # get system FQDN
-    my $FQDN = $Kernel::OM->Get('Kernel::Config')->Get('FQDN');
+    # get system ExtFQDN
+    my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+    my $ExtFQDN = $ConfigObject->Get('ExtFQDN') || $ConfigObject->Get('FQDN');
 
     # return UniqueID
-    return "$StartTimeStrg-$Hash\@$FQDN";
+    return "$StartTimeStrg-$Hash\@$ExtFQDN";
 }
 
 =head2 AppointmentUpcomingGet()

--- a/Kernel/System/Email.pm
+++ b/Kernel/System/Email.pm
@@ -1011,9 +1011,9 @@ sub _MessageIDCreate {
     my ( $Self, %Param ) = @_;
 
     my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
-    my $ExtFQDN = $ConfigObject->Get('ExtFQDN') || $ConfigObject->Get('FQDN');
+    my $ExternalFQDN = $ConfigObject->Get('ExternalFQDN') || $ConfigObject->Get('FQDN');
 
-    return '<' . time() . '.' . rand(999999) . '@' . $ExtFQDN . '>';
+    return '<' . time() . '.' . rand(999999) . '@' . $ExternalFQDN . '>';
 }
 
 sub _CreateMimeEntity {

--- a/Kernel/System/Email.pm
+++ b/Kernel/System/Email.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/System/Email.pm
+++ b/Kernel/System/Email.pm
@@ -1010,9 +1010,10 @@ sub _EncodeMIMEWords {
 sub _MessageIDCreate {
     my ( $Self, %Param ) = @_;
 
-    my $FQDN = $Kernel::OM->Get('Kernel::Config')->Get('FQDN');
+    my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+    my $ExtFQDN = $ConfigObject->Get('ExtFQDN') || $ConfigObject->Get('FQDN');
 
-    return '<' . time() . '.' . rand(999999) . '@' . $FQDN . '>';
+    return '<' . time() . '.' . rand(999999) . '@' . $ExtFQDN . '>';
 }
 
 sub _CreateMimeEntity {

--- a/Kernel/System/Email.pm
+++ b/Kernel/System/Email.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/System/HTMLUtils.pm
+++ b/Kernel/System/HTMLUtils.pm
@@ -1248,7 +1248,7 @@ sub EmbeddedImagesExtract {
     }
 
     my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
-    my $ExtFQDN = $ConfigObject->Get('ExtFQDN') || $ConfigObject->Get('FQDN');
+    my $ExternalFQDN = $ConfigObject->Get('ExternalFQDN') || $ConfigObject->Get('FQDN');
 
     ${ $Param{DocumentRef} } =~ s{(src=")(data:image/)(png|gif|jpg|jpeg|bmp)(;base64,)(.+?)(")}{
 
@@ -1256,7 +1256,7 @@ sub EmbeddedImagesExtract {
 
         my $FileName     = 'pasted-' . time() . '-' . int(rand(1000000)) . '.' . $3;
         my $ContentType  = "image/$3; name=\"$FileName\"";
-        my $ContentID    = 'pasted.' . time() . '.' . int(rand(1000000)) . '@' . $ExtFQDN;
+        my $ContentID    = 'pasted.' . time() . '.' . int(rand(1000000)) . '@' . $ExternalFQDN;
 
         my $AttachmentData = {
             Content     => decode_base64($Base64String),

--- a/Kernel/System/HTMLUtils.pm
+++ b/Kernel/System/HTMLUtils.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/System/HTMLUtils.pm
+++ b/Kernel/System/HTMLUtils.pm
@@ -1247,14 +1247,16 @@ sub EmbeddedImagesExtract {
         return;
     }
 
-    my $FQDN = $Kernel::OM->Get('Kernel::Config')->Get('FQDN');
+    my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+    my $ExtFQDN = $ConfigObject->Get('ExtFQDN') || $ConfigObject->Get('FQDN');
+
     ${ $Param{DocumentRef} } =~ s{(src=")(data:image/)(png|gif|jpg|jpeg|bmp)(;base64,)(.+?)(")}{
 
         my $Base64String = $5;
 
         my $FileName     = 'pasted-' . time() . '-' . int(rand(1000000)) . '.' . $3;
         my $ContentType  = "image/$3; name=\"$FileName\"";
-        my $ContentID    = 'pasted.' . time() . '.' . int(rand(1000000)) . '@' . $FQDN;
+        my $ContentID    = 'pasted.' . time() . '.' . int(rand(1000000)) . '@' . $ExtFQDN;
 
         my $AttachmentData = {
             Content     => decode_base64($Base64String),

--- a/Kernel/System/HTMLUtils.pm
+++ b/Kernel/System/HTMLUtils.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/System/Ticket/Article/Backend/Email.pm
+++ b/Kernel/System/Ticket/Article/Backend/Email.pm
@@ -276,11 +276,13 @@ sub ArticleSend {
         AttachmentsRef => $Param{Attachment},
     );
 
+    my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+
     # create article
     my $Time      = $DateTimeObject->ToEpoch();
     my $Random    = rand 999999;
-    my $FQDN      = $Kernel::OM->Get('Kernel::Config')->Get('FQDN');
-    my $MessageID = "<$Time.$Random\@$FQDN>";
+    my $ExtFQDN   = $ConfigObject->Get('ExtFQDN') || $ConfigObject->Get('FQDN');
+    my $MessageID = "<$Time.$Random\@$ExtFQDN>";
     my $ArticleID = $Self->ArticleCreate(
         %Param,
         MessageID => $MessageID,
@@ -366,13 +368,14 @@ sub ArticleBounce {
         }
     }
 
+    my $ConfigObject   = $Kernel::OM->Get('Kernel::Config');
     my $DateTimeObject = $Kernel::OM->Create('Kernel::System::DateTime');
 
     # create message id
     my $Time         = $DateTimeObject->ToEpoch();
     my $Random       = rand 999999;
-    my $FQDN         = $Kernel::OM->Get('Kernel::Config')->Get('FQDN');
-    my $NewMessageID = "<$Time.$Random.0\@$FQDN>";
+    my $ExtFQDN      = $ConfigObject->Get('ExtFQDN') || $ConfigObject->Get('FQDN');
+    my $NewMessageID = "<$Time.$Random.0\@$ExtFQDN>";
     my $Email        = $Self->ArticlePlain( ArticleID => $Param{ArticleID} );
 
     # check if plain email exists

--- a/Kernel/System/Ticket/Article/Backend/Email.pm
+++ b/Kernel/System/Ticket/Article/Backend/Email.pm
@@ -281,8 +281,8 @@ sub ArticleSend {
     # create article
     my $Time      = $DateTimeObject->ToEpoch();
     my $Random    = rand 999999;
-    my $ExtFQDN   = $ConfigObject->Get('ExtFQDN') || $ConfigObject->Get('FQDN');
-    my $MessageID = "<$Time.$Random\@$ExtFQDN>";
+    my $ExternalFQDN   = $ConfigObject->Get('ExternalFQDN') || $ConfigObject->Get('FQDN');
+    my $MessageID = "<$Time.$Random\@$ExternalFQDN>";
     my $ArticleID = $Self->ArticleCreate(
         %Param,
         MessageID => $MessageID,
@@ -374,8 +374,8 @@ sub ArticleBounce {
     # create message id
     my $Time         = $DateTimeObject->ToEpoch();
     my $Random       = rand 999999;
-    my $ExtFQDN      = $ConfigObject->Get('ExtFQDN') || $ConfigObject->Get('FQDN');
-    my $NewMessageID = "<$Time.$Random.0\@$ExtFQDN>";
+    my $ExternalFQDN      = $ConfigObject->Get('ExternalFQDN') || $ConfigObject->Get('FQDN');
+    my $NewMessageID = "<$Time.$Random.0\@$ExternalFQDN>";
     my $Email        = $Self->ArticlePlain( ArticleID => $Param{ArticleID} );
 
     # check if plain email exists

--- a/Kernel/System/Ticket/Article/Backend/Email.pm
+++ b/Kernel/System/Ticket/Article/Backend/Email.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/System/Ticket/Article/Backend/Email.pm
+++ b/Kernel/System/Ticket/Article/Backend/Email.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/System/Web/UploadCache/DB.pm
+++ b/Kernel/System/Web/UploadCache/DB.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/System/Web/UploadCache/DB.pm
+++ b/Kernel/System/Web/UploadCache/DB.pm
@@ -98,9 +98,9 @@ sub FormIDAddFile {
 
         my $Random = rand 999999;
         my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
-        my $ExtFQDN = $ConfigObject->Get('ExtFQDN') || $ConfigObject->Get('FQDN');
+        my $ExternalFQDN = $ConfigObject->Get('ExternalFQDN') || $ConfigObject->Get('FQDN');
 
-        $ContentID = "$Disposition$Random.$Param{FormID}\@$ExtFQDN";
+        $ContentID = "$Disposition$Random.$Param{FormID}\@$ExternalFQDN";
     }
 
     # write attachment to db

--- a/Kernel/System/Web/UploadCache/DB.pm
+++ b/Kernel/System/Web/UploadCache/DB.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -97,9 +98,10 @@ sub FormIDAddFile {
     if ( !$ContentID && lc $Disposition eq 'inline' ) {
 
         my $Random = rand 999999;
-        my $FQDN   = $Kernel::OM->Get('Kernel::Config')->Get('FQDN');
+        my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+        my $ExtFQDN = $ConfigObject->Get('ExtFQDN') || $ConfigObject->Get('FQDN');
 
-        $ContentID = "$Disposition$Random.$Param{FormID}\@$FQDN";
+        $ContentID = "$Disposition$Random.$Param{FormID}\@$ExtFQDN";
     }
 
     # write attachment to db

--- a/Kernel/System/Web/UploadCache/FS.pm
+++ b/Kernel/System/Web/UploadCache/FS.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -108,9 +109,10 @@ sub FormIDAddFile {
     if ( !$ContentID && lc $Disposition eq 'inline' ) {
 
         my $Random = rand 999999;
-        my $FQDN   = $Kernel::OM->Get('Kernel::Config')->Get('FQDN');
+        my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+        my $ExtFQDN = $ConfigObject->Get('ExtFQDN') || $ConfigObject->Get('FQDN');
 
-        $ContentID = "$Disposition$Random.$Param{FormID}\@$FQDN";
+        $ContentID = "$Disposition$Random.$Param{FormID}\@$ExtFQDN";
     }
 
     # create cache subdirectory if not exist

--- a/Kernel/System/Web/UploadCache/FS.pm
+++ b/Kernel/System/Web/UploadCache/FS.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/System/Web/UploadCache/FS.pm
+++ b/Kernel/System/Web/UploadCache/FS.pm
@@ -109,9 +109,9 @@ sub FormIDAddFile {
 
         my $Random = rand 999999;
         my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
-        my $ExtFQDN = $ConfigObject->Get('ExtFQDN') || $ConfigObject->Get('FQDN');
+        my $ExternalFQDN = $ConfigObject->Get('ExternalFQDN') || $ConfigObject->Get('FQDN');
 
-        $ContentID = "$Disposition$Random.$Param{FormID}\@$ExtFQDN";
+        $ContentID = "$Disposition$Random.$Param{FormID}\@$ExternalFQDN";
     }
 
     # create cache subdirectory if not exist


### PR DESCRIPTION
<!--
  You are amazing! 🚀
  Thanks for contributing to the Znuny community project!
  Please, DO NOT DELETE ANY TEXT from this template (unless instructed)!
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why this pull request should be accepted. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Znuny uses the fully qualified domain name (FQDN SysConfig setting)
for external IDs generation (i.e. Message-ID in e-mail messages,
ContentID for pasted images). If Znuny instance uses internal
domain for FQDN, this internal domain name will leak to third
parties in e-mail message headers which may be not desirable.

This mod introduces new SysConfig option ExternalFQDN which allowes
one to define the fully qualified domain name for external IDs
generation (i.e. Message-ID in e-mail messages, Content-ID for
pasted images).

If ExternalFQDN is not defined in SysConfig (default), Znuny will
still use FQDN setting for Message-ID and ContentID generation.


## Additional information
<!--
  Details are important and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  Note: Remove this section if not needed.

  If a PR is related to an issue, please use the 'Linked issues' function on the sidebar.
-->
- We treat internal info leaking as bug so this PR is bugfix not feature in our opinion.
- Author-Change-Id: IB#1009570

## Checklist
<!--
  Put an '✖️' in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  ❕ - nice to have
  ❗ - required before review
-->

- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [x] Local ZnunyCodePolicy run passes successfully.(❕)
- [x] Local unit tests pass.(❕)
- [ ] GitHub workflow ZnunyCodePolicy passes.(❗)
- [ ] GitHub workflow unit tests pass.(❗)

<!--
  Thank you for contributing ❤

  Znuny @znuny/znuny
-->
