### PR TITLE
Fixed LDAP user sync.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,3 @@
-# 6.0.35 2021-xx-xx
- - 2021-05-12 LDAP user sync fixes.
-
 # 6.0.34 2021-04-21
  - 2021-04-14 Updated jquery-validate from version 1.16.0 to 1.19.3 (CVE-2021-21252).
  - 2021-04-13 Fixed product URL in HTTP Headers. Thanks to Renée Bäcker (@reneeb) [#42](https://github.com/znuny/Znuny/pull/42)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# 6.0.35 2021-xx-xx
+ - 2021-05-12 LDAP user sync fixes.
+
 # 6.0.34 2021-04-21
  - 2021-04-14 Updated jquery-validate from version 1.16.0 to 1.19.3 (CVE-2021-21252).
  - 2021-04-13 Fixed product URL in HTTP Headers. Thanks to Renée Bäcker (@reneeb) [#42](https://github.com/znuny/Znuny/pull/42)

--- a/Kernel/System/Auth/Sync/LDAP.pm
+++ b/Kernel/System/Auth/Sync/LDAP.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -267,9 +268,8 @@ sub Sync {
         # add new user
         if ( %SyncUser && !$UserID ) {
             $UserID = $UserObject->UserAdd(
-                UserTitle => 'Mr/Mrs',
                 UserLogin => $Param{User},
-                %SyncUser,
+                %SyncUser, # Must contain other parameters required by UserAdd.
                 UserType     => 'User',
                 ValidID      => 1,
                 ChangeUserID => 1,
@@ -333,17 +333,20 @@ sub Sync {
             my $AttributeChange;
             ATTRIBUTE:
             for my $Attribute ( sort keys %SyncUser ) {
-                next ATTRIBUTE if defined $SyncUser{$Attribute} && $SyncUser{$Attribute} eq $UserData{$Attribute};
+                # Treat undef and empty strings as equal.
+                my $SyncUserAttribute = $SyncUser{$Attribute} // '';
+                my $UserDataAttribute = $UserData{$Attribute} // '';
+                next ATTRIBUTE if $SyncUserAttribute eq $UserDataAttribute;
                 $AttributeChange = 1;
                 last ATTRIBUTE;
             }
 
             if ($AttributeChange) {
                 $UserObject->UserUpdate(
-                    %UserData,
+                    ValidID   => $UserData{ValidID}, # May be not present in %SyncUser and is required by UserUpdate.
                     UserID    => $UserID,
                     UserLogin => $Param{User},
-                    %SyncUser,
+                    %SyncUser, # Must contain other parameters required by UserUpdate.
                     UserType     => 'User',
                     ChangeUserID => 1,
                 );

--- a/Kernel/System/Auth/Sync/LDAP.pm
+++ b/Kernel/System/Auth/Sync/LDAP.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/System/User.pm
+++ b/Kernel/System/User.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -1237,6 +1238,7 @@ sub SetPreferences {
         UserLastname  => 1,
         UserFullname  => 1,
         UserTitle     => 1,
+        UserType      => 1,
         ChangeTime    => 1,
         CreateTime    => 1,
         ValidID       => 1,
@@ -1250,11 +1252,10 @@ sub SetPreferences {
         NoOutOfOffice => 1,
     );
 
-    # no updated needed
-    return 1
-        if defined $User{ $Param{Key} }
-        && defined $Param{Value}
-        && $User{ $Param{Key} } eq $Param{Value};
+    # No update needed (treat undef and empty strings as equal).
+    my $UserValue = $User{ $Param{Key} } // '';
+    my $ParamValue = $Param{Value} // '';
+    return 1 if $UserValue eq $ParamValue;
 
     $Self->_UserCacheClear( UserID => $Param{UserID} );
 

--- a/Kernel/System/User.pm
+++ b/Kernel/System/User.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you


### PR DESCRIPTION
<!--
  You are amazing! 🚀
  Thanks for contributing to the Znuny community project!
  Please, DO NOT DELETE ANY TEXT from this template (unless instructed)!
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why this pull request should be accepted. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fixes undef/empty string comparisons that may occur between data
stored in DB and data coming from LDAP; i.e. if phone number
coming from LDAP is undef, should not cause SQL update if
already undef/empty.

This mod also disallows setting UserType as user preference
(similar to other native data) and protects UserUpdate()
called from LDAP sync routine from touching properties other
than specified in LDAP sync map (to avoid problems if other
User* keys are/will be present in %UserData that are not
user preferences).

## Type of change
- '1 - 🐞 bug 🐞'            - Bugfix (non-breaking change which fixes an issue)

## Additional information
<!--
  Details are important and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  Note: Remove this section if not needed.

  If a PR is related to an issue, please use the 'Linked issues' function on the sidebar.
-->
- Author-Change-Id: IB#1014533

## Checklist
<!--
  Put an '✖️' in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  ❕ - nice to have
  ❗ - required before review
-->

- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [x] Local ZnunyCodePolicy run passes successfully.(❕)
- [x] Local unit tests pass.(❕)
- [x] GitHub workflow ZnunyCodePolicy passes.(❗)
- [x] GitHub workflow unit tests pass.(❗)

<!--
  Thank you for contributing ❤

  Znuny @znuny/znuny
-->
