### PR TITLE
Fixed handling whitespaces around '=' in Content-Type/charset token.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# 6.0.35 2021-xx-xx
+ - 2021-05-13 Fixed handling whitespaces around = in Content-Type/charset token.
+
 # 6.0.34 2021-04-21
  - 2021-04-14 Updated jquery-validate from version 1.16.0 to 1.19.3 (CVE-2021-21252).
  - 2021-04-13 Fixed product URL in HTTP Headers. Thanks to Renée Bäcker (@reneeb) [#42](https://github.com/znuny/Znuny/pull/42)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,3 @@
-# 6.0.35 2021-xx-xx
- - 2021-05-13 Fixed handling whitespaces around = in Content-Type/charset token.
-
 # 6.0.34 2021-04-21
  - 2021-04-14 Updated jquery-validate from version 1.16.0 to 1.19.3 (CVE-2021-21252).
  - 2021-04-13 Fixed product URL in HTTP Headers. Thanks to Renée Bäcker (@reneeb) [#42](https://github.com/znuny/Znuny/pull/42)

--- a/Kernel/GenericInterface/Operation/Ticket/TicketCreate.pm
+++ b/Kernel/GenericInterface/Operation/Ticket/TicketCreate.pm
@@ -2,7 +2,6 @@
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
 # Copyright (C) 2021 maxence business consulting GmbH, http://www.maxence.de
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/GenericInterface/Operation/Ticket/TicketCreate.pm
+++ b/Kernel/GenericInterface/Operation/Ticket/TicketCreate.pm
@@ -2,6 +2,7 @@
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
 # Copyright (C) 2021 maxence business consulting GmbH, http://www.maxence.de
+# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -923,9 +924,9 @@ sub _CheckArticle {
 
         # check Charset part
         my $Charset = '';
-        if ( $Article->{ContentType} =~ /charset=/i ) {
+        if ( $Article->{ContentType} =~ /charset\s*=\s*/i ) {
             $Charset = $Article->{ContentType};
-            $Charset =~ s/.+?charset=("|'|)(\w+)/$2/gi;
+            $Charset =~ s/.+?charset\s*=\s*("|'|)(\w+)/$2/gi;
             $Charset =~ s/"|'//g;
             $Charset =~ s/(.+?);.*/$1/g;
         }
@@ -1153,9 +1154,9 @@ sub _CheckAttachment {
 
         # check Charset part
         my $Charset = '';
-        if ( $Attachment->{ContentType} =~ /charset=/i ) {
+        if ( $Attachment->{ContentType} =~ /charset\s*=\s*/i ) {
             $Charset = $Attachment->{ContentType};
-            $Charset =~ s/.+?charset=("|'|)(\w+)/$2/gi;
+            $Charset =~ s/.+?charset\s*=\s*("|'|)(\w+)/$2/gi;
             $Charset =~ s/"|'//g;
             $Charset =~ s/(.+?);.*/$1/g;
         }

--- a/Kernel/GenericInterface/Operation/Ticket/TicketUpdate.pm
+++ b/Kernel/GenericInterface/Operation/Ticket/TicketUpdate.pm
@@ -2,6 +2,7 @@
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
 # Copyright (C) 2021 maxence business consulting GmbH, http://www.maxence.de
+# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -993,9 +994,9 @@ sub _CheckArticle {
 
         # check Charset part
         my $Charset = '';
-        if ( $Article->{ContentType} =~ /charset=/i ) {
+        if ( $Article->{ContentType} =~ /charset\s*=\s*/i ) {
             $Charset = $Article->{ContentType};
-            $Charset =~ s/.+?charset=("|'|)(\w+)/$2/gi;
+            $Charset =~ s/.+?charset\s*=\s*("|'|)(\w+)/$2/gi;
             $Charset =~ s/"|'//g;
             $Charset =~ s/(.+?);.*/$1/g;
         }
@@ -1253,9 +1254,9 @@ sub _CheckAttachment {
 
         # check Charset part
         my $Charset = '';
-        if ( $Attachment->{ContentType} =~ /charset=/i ) {
+        if ( $Attachment->{ContentType} =~ /charset\s*=\s*/i ) {
             $Charset = $Attachment->{ContentType};
-            $Charset =~ s/.+?charset=("|'|)(\w+)/$2/gi;
+            $Charset =~ s/.+?charset\s*=\s*("|'|)(\w+)/$2/gi;
             $Charset =~ s/"|'//g;
             $Charset =~ s/(.+?);.*/$1/g;
         }

--- a/Kernel/GenericInterface/Operation/Ticket/TicketUpdate.pm
+++ b/Kernel/GenericInterface/Operation/Ticket/TicketUpdate.pm
@@ -2,7 +2,6 @@
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
 # Copyright (C) 2021 maxence business consulting GmbH, http://www.maxence.de
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/GenericInterface/Transport/HTTP/REST.pm
+++ b/Kernel/GenericInterface/Transport/HTTP/REST.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/GenericInterface/Transport/HTTP/REST.pm
+++ b/Kernel/GenericInterface/Transport/HTTP/REST.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -263,7 +264,7 @@ sub ProviderProcessRequest {
 
     # Convert char-set if necessary.
     my $ContentCharset;
-    if ( $ENV{'CONTENT_TYPE'} =~ m{ \A .* charset= ["']? ( [^"']+ ) ["']? \z }xmsi ) {
+    if ( $ENV{'CONTENT_TYPE'} =~ m{ \A .* charset\s*=\s* ["']? ( [^"']+ ) ["']? \z }xmsi ) {
         $ContentCharset = $1;
     }
     if ( $ContentCharset && $ContentCharset !~ m{ \A utf [-]? 8 \z }xmsi ) {

--- a/Kernel/GenericInterface/Transport/HTTP/SOAP.pm
+++ b/Kernel/GenericInterface/Transport/HTTP/SOAP.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -173,7 +174,7 @@ sub ProviderProcessRequest {
 
     # Convert charset if necessary.
     my $ContentCharset;
-    if ( $ENV{'CONTENT_TYPE'} =~ m{ \A ( .+ ) ;\s*charset= ["']{0,1} ( .+? ) ["']{0,1} (;|\z) }xmsi ) {
+    if ( $ENV{'CONTENT_TYPE'} =~ m{ \A ( .+ ) ;\s*charset\s*=\s* ["']{0,1} ( .+? ) ["']{0,1} (;|\z) }xmsi ) {
 
         # Remember content type for the response.
         $Self->{ContentType} = $1;

--- a/Kernel/GenericInterface/Transport/HTTP/SOAP.pm
+++ b/Kernel/GenericInterface/Transport/HTTP/SOAP.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/Output/HTML/Article/MIMEBase.pm
+++ b/Kernel/Output/HTML/Article/MIMEBase.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -298,7 +299,7 @@ sub ArticlePreview {
             # Get the charset directly from the attachment hash and convert content to the internal charset (utf-8).
             #   Please see bug#13367 for more information.
             my $Charset;
-            if ( $Data{ContentType} =~ m/.+?charset=("|'|)(?<Charset>.+)/ig ) {
+            if ( $Data{ContentType} =~ m/.+?charset\s*=\s*("|'|)(?<Charset>.+)/ig ) {
                 $Charset = $+{Charset};
                 $Charset =~ s/"|'//g;
             }

--- a/Kernel/Output/HTML/Article/MIMEBase.pm
+++ b/Kernel/Output/HTML/Article/MIMEBase.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/Output/HTML/Layout.pm
+++ b/Kernel/Output/HTML/Layout.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/Output/HTML/Layout.pm
+++ b/Kernel/Output/HTML/Layout.pm
@@ -5006,7 +5006,7 @@ sub RichTextDocumentServe {
 
     # Get charset from passed content type parameter.
     my $Charset;
-    if ( $Param{Data}->{ContentType} =~ m/.+?charset=("|'|)(.+)/ig ) {
+    if ( $Param{Data}->{ContentType} =~ m/.+?charset\s*=\s*("|'|)(.+)/ig ) {
         $Charset = $2;
         $Charset =~ s/"|'//g;
     }
@@ -5026,7 +5026,7 @@ sub RichTextDocumentServe {
 
         # Replace charset in content type and content.
         $Param{Data}->{ContentType} =~ s/\Q$Charset\E/utf-8/gi;
-        if ( !( $Param{Data}->{Content} =~ s/(<meta[^>]+charset=("|'|))\Q$Charset\E/$1utf-8/gi ) ) {
+        if ( !( $Param{Data}->{Content} =~ s/(<meta[^>]+charset\s*=\s*("|'|))\Q$Charset\E/$1utf-8/gi ) ) {
 
             # Add explicit charset if missing.
             $Param{Data}->{Content}

--- a/Kernel/Output/HTML/Layout.pm
+++ b/Kernel/Output/HTML/Layout.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/Output/HTML/Layout/Article.pm
+++ b/Kernel/Output/HTML/Layout/Article.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/Output/HTML/Layout/Article.pm
+++ b/Kernel/Output/HTML/Layout/Article.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -290,7 +291,7 @@ sub ArticleQuote {
                 FileID    => $HTMLBodyAttachmentID,
             );
             my $Charset = $AttachmentHTML{ContentType} || '';
-            $Charset =~ s/.+?charset=("|'|)(\w+)/$2/gi;
+            $Charset =~ s/.+?charset\s*=\s*("|'|)(\w+)/$2/gi;
             $Charset =~ s/"|'//g;
             $Charset =~ s/(.+?);.*/$1/g;
 

--- a/Kernel/System/EmailParser.pm
+++ b/Kernel/System/EmailParser.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -425,7 +426,7 @@ sub GetReturnContentType {
     my $Self = shift;
 
     my $ContentType = $Self->GetContentType();
-    $ContentType =~ s/(charset=)(.*)/$1utf-8/ig;
+    $ContentType =~ s/charset\s*=.*/charset=utf-8/ig;
 
     # debug
     if ( $Self->{Debug} > 0 ) {
@@ -841,7 +842,7 @@ sub PartsAttachments {
 
         # Also replace charset in meta tags of HTML emails.
         if ( $MimeType eq 'text/html' ) {
-            $PartData{Content} =~ s/(<meta[^>]+charset=("|'|))\Q$OldCharset\E/$1utf-8/gi;
+            $PartData{Content} =~ s/(<meta[^>]+charset\s*=\s*("|'|))\Q$OldCharset\E/$1utf-8/gi;
         }
 
         $PartData{Filesize} = bytes::length( $PartData{Content} );

--- a/Kernel/System/EmailParser.pm
+++ b/Kernel/System/EmailParser.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/System/ProcessManagement/TransitionAction/Base.pm
+++ b/Kernel/System/ProcessManagement/TransitionAction/Base.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -269,7 +270,7 @@ sub _ReplaceAdditionalAttributes {
                 );
 
                 my $Charset = $AttachmentHTML{ContentType} || '';
-                $Charset =~ s/.+?charset=("|'|)(\w+)/$2/gi;
+                $Charset =~ s/.+?charset\s*=\s*("|'|)(\w+)/$2/gi;
                 $Charset =~ s/"|'//g;
                 $Charset =~ s/(.+?);.*/$1/g;
 

--- a/Kernel/System/ProcessManagement/TransitionAction/Base.pm
+++ b/Kernel/System/ProcessManagement/TransitionAction/Base.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/System/Ticket/Article/Backend/MIMEBase.pm
+++ b/Kernel/System/Ticket/Article/Backend/MIMEBase.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -216,9 +217,9 @@ sub ArticleCreate {
             }
         }
         $Param{Charset} = '';
-        if ( $Param{ContentType} =~ /charset=/i ) {
+        if ( $Param{ContentType} =~ /charset\s*=\s*/i ) {
             $Param{Charset} = $Param{ContentType};
-            $Param{Charset} =~ s/.+?charset=("|'|)(\w+)/$2/gi;
+            $Param{Charset} =~ s/.+?charset\s*=\s*("|'|)(\w+)/$2/gi;
             $Param{Charset} =~ s/"|'//g;
             $Param{Charset} =~ s/(.+?);.*/$1/g;
 
@@ -441,7 +442,7 @@ sub ArticleCreate {
     for my $Attachment (@AttachmentConvert) {
 
         if (
-            $Attachment->{ContentType} eq "text/html; charset=\"$Param{Charset}\""
+            $Attachment->{ContentType} =~ /^text\/html; charset\s*=\s*"$Param{Charset}"$/i
             && $Attachment->{Filename} eq 'file-2'
             )
         {
@@ -815,9 +816,9 @@ sub ArticleGet {
         );
 
         # Determine charset.
-        if ( $Data{ContentType} && $Data{ContentType} =~ /charset=/i ) {
+        if ( $Data{ContentType} && $Data{ContentType} =~ /charset\s*=\s*/i ) {
             $Data{Charset} = $Data{ContentType};
-            $Data{Charset} =~ s/.+?charset=("|'|)(\w+)/$2/gi;
+            $Data{Charset} =~ s/.+?charset\s*=\s*("|'|)(\w+)/$2/gi;
             $Data{Charset} =~ s/"|'//g;
             $Data{Charset} =~ s/(.+?);.*/$1/g;
         }

--- a/Kernel/System/Ticket/Article/Backend/MIMEBase.pm
+++ b/Kernel/System/Ticket/Article/Backend/MIMEBase.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/scripts/test/Layout/RichTextDocumentServe.t
+++ b/scripts/test/Layout/RichTextDocumentServe.t
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/scripts/test/Layout/RichTextDocumentServe.t
+++ b/scripts/test/Layout/RichTextDocumentServe.t
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -359,6 +360,19 @@ EOF
         Result             => {
             Content     => 'Link <a href="http://test.example" target="_blank">http://test.example</a>',
             ContentType => 'text/html; charset="utf-8"',
+        },
+    },
+    {
+        Name => 'Standard - extra spaces after charset and = tokens',
+        Data => {
+            Content     => 'Some Content',
+            ContentType => 'text/html; charset = "utf-8"',
+        },
+        Attachments => {},
+        URL         => 'Action=SomeAction;FileID=',
+        Result      => {
+            Content     => 'Some Content',
+            ContentType => 'text/html; charset = "utf-8"',
         },
     },
 );


### PR DESCRIPTION
<!--
  You are amazing! 🚀
  Thanks for contributing to the Znuny community project!
  Please, DO NOT DELETE ANY TEXT from this template (unless instructed)!
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why this pull request should be accepted. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This mod allowes Znuny to handle spaces around = in Content-Type/charset
like in message below:

    Return-Path: <test@test.loc>
    Date: Wed, 30 Apr 2014 12:04:07 +0200
    From: test <test@test.loc>
    To: <test@test.loc>
    Subject: test
    MIME-Version: 1.0
    Content-Type: text/plain; charset = "utf-8"
    Content-Transfer-Encoding: 8bit
    Message-ID: <test1003@test.loc>

    żółw

Extra spaces are tolerated by http://tools.ietf.org/tools/msglint/
validator (warnings only) and e-mail clients like Mozilla Thunderbird;
Znuny should allow it too to avoid problems (i.e. errors in syslog)
with e-mail messages using spaces as above. 

## Type of change
- '1 - 🐞 bug 🐞'            - Bugfix (non-breaking change which fixes an issue)

## Additional information
<!--
  Details are important and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  Note: Remove this section if not needed.

  If a PR is related to an issue, please use the 'Linked issues' function on the sidebar.
-->
- Author-Change-Id: IB#1015440

## Checklist
<!--
  Put an '✖️' in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  ❕ - nice to have
  ❗ - required before review
-->

- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [x] You improved or added new unit tests.(❕)
- [x] Local ZnunyCodePolicy run passes successfully.(❕)
- [x] Local unit tests pass.(❕)
- [x] GitHub workflow ZnunyCodePolicy passes.(❗)
- [x] GitHub workflow unit tests pass.(❗)

<!--
  Thank you for contributing ❤

  Znuny @znuny/znuny
-->
