### PR TITLE
Fixed unnecessary merge errors when link already exists

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# 6.0.35 2021-xx-xx
+ - 2016-06-21 Fixed unnecessary merge errors when link already exists.
+
 # 6.0.34 2021-04-21
  - 2021-04-14 Updated jquery-validate from version 1.16.0 to 1.19.3 (CVE-2021-21252).
  - 2021-04-13 Fixed product URL in HTTP Headers. Thanks to Renée Bäcker (@reneeb) [#42](https://github.com/znuny/Znuny/pull/42)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,3 @@
-# 6.0.35 2021-xx-xx
- - 2016-06-21 Fixed unnecessary merge errors when link already exists.
-
 # 6.0.34 2021-04-21
  - 2021-04-14 Updated jquery-validate from version 1.16.0 to 1.19.3 (CVE-2021-21252).
  - 2021-04-13 Fixed product URL in HTTP Headers. Thanks to Renée Bäcker (@reneeb) [#42](https://github.com/znuny/Znuny/pull/42)

--- a/Kernel/System/LinkObject.pm
+++ b/Kernel/System/LinkObject.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -316,13 +317,14 @@ sub PossibleLinkList {
 add a new link between two elements
 
     $True = $LinkObject->LinkAdd(
-        SourceObject => 'Ticket',
-        SourceKey    => '321',
-        TargetObject => 'FAQ',
-        TargetKey    => '5',
-        Type         => 'ParentChild',
-        State        => 'Valid',
-        UserID       => 1,
+        SourceObject   => 'Ticket',
+        SourceKey      => '321',
+        TargetObject   => 'FAQ',
+        TargetKey      => '5',
+        Type           => 'ParentChild',
+        State          => 'Valid',
+        UserID         => 1,
+        NoticeIfExists => 1, # optional; notice not error if link exists
     );
 
 =cut
@@ -437,8 +439,11 @@ sub LinkAdd {
         if ( $Existing{StateID} ne $StateID ) {
 
             $Kernel::OM->Get('Kernel::System::Log')->Log(
-                Priority => 'error',
-                Message  => "Link already exists between these two objects "
+                Priority => $Param{NoticeIfExists} ? 'notice' : 'error',
+                Message  => "Cannot create a '$Param{Type}' link between "
+                    . "$Param{SourceObject} $Param{SourceKey} and "
+                    . "$Param{TargetObject} $Param{TargetKey}! "
+                    . "Link already exists between these two objects "
                     . "with a different state id '$Existing{StateID}'!",
             );
             return;
@@ -455,8 +460,11 @@ sub LinkAdd {
 
         # log error
         $Kernel::OM->Get('Kernel::System::Log')->Log(
-            Priority => 'error',
-            Message  => 'Link already exists between these two objects in opposite direction!',
+            Priority => $Param{NoticeIfExists} ? 'notice' : 'error',
+            Message  => "Cannot create a '$Param{Type}' link between "
+                . "$Param{SourceObject} $Param{SourceKey} and "
+                . "$Param{TargetObject} $Param{TargetKey}! "
+                . 'Link already exists between these two objects in opposite direction!',
         );
         return;
     }
@@ -495,8 +503,11 @@ sub LinkAdd {
 
             # existing link type is in a type group with the new link
             $Kernel::OM->Get('Kernel::System::Log')->Log(
-                Priority => 'error',
-                Message  => 'Another Link already exists within the same type group!',
+                Priority => $Param{NoticeIfExists} ? 'notice' : 'error',
+                Message  => "Cannot create a '$Param{Type}' link between "
+                    . "$Param{SourceObject} $Param{SourceKey} and "
+                    . "$Param{TargetObject} $Param{TargetKey}! "
+                    . 'Another Link already exists within the same type group!',
             );
 
             return;

--- a/Kernel/System/Ticket.pm
+++ b/Kernel/System/Ticket.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -6070,13 +6071,14 @@ sub TicketMerge {
 
     # link tickets
     $Kernel::OM->Get('Kernel::System::LinkObject')->LinkAdd(
-        SourceObject => 'Ticket',
-        SourceKey    => $Param{MainTicketID},
-        TargetObject => 'Ticket',
-        TargetKey    => $Param{MergeTicketID},
-        Type         => 'ParentChild',
-        State        => 'Valid',
-        UserID       => $Param{UserID},
+        SourceObject   => 'Ticket',
+        SourceKey      => $Param{MainTicketID},
+        TargetObject   => 'Ticket',
+        TargetKey      => $Param{MergeTicketID},
+        Type           => 'ParentChild',
+        State          => 'Valid',
+        UserID         => $Param{UserID},
+        NoticeIfExists => 1,
     );
 
     # Update change time and user ID for main ticket.


### PR DESCRIPTION
<!--
  You are amazing! 🚀
  Thanks for contributing to the Znuny community project!
  Please, DO NOT DELETE ANY TEXT from this template (unless instructed)!
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why this pull request should be accepted. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Znuny throws error messages like

    Link already exists between these two objects in opposite direction
    Another Link already exists within the same type group!

when merging tickets with existing links between it.

This mod changes such message priority from error to notice.

Author-Change-Id: IB#1016061

## Type of change
- '1 - 🐞 bug 🐞'            - Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
  Put an '✖️' in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  ❕ - nice to have
  ❗ - required before review
-->

- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [x] Local ZnunyCodePolicy run passes successfully.(❕)
- [x] Local unit tests pass.(❕)
- [ ] GitHub workflow ZnunyCodePolicy passes.(❗)
- [ ] GitHub workflow unit tests pass.(❗)

<!--
  Thank you for contributing ❤

  Znuny @znuny/znuny
-->
