### PR TITLE
Fixed inline image corruption when uploading file with the same name

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# 6.0.35 2021-xx-xx
+ - 2021-05-17 Fixed inline image corruption when uploading file with the same name.
+
 # 6.0.34 2021-04-21
  - 2021-04-14 Updated jquery-validate from version 1.16.0 to 1.19.3 (CVE-2021-21252).
  - 2021-04-13 Fixed product URL in HTTP Headers. Thanks to Renée Bäcker (@reneeb) [#42](https://github.com/znuny/Znuny/pull/42)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,3 @@
-# 6.0.35 2021-xx-xx
- - 2021-05-17 Fixed inline image corruption when uploading file with the same name.
-
 # 6.0.34 2021-04-21
  - 2021-04-14 Updated jquery-validate from version 1.16.0 to 1.19.3 (CVE-2021-21252).
  - 2021-04-13 Fixed product URL in HTTP Headers. Thanks to Renée Bäcker (@reneeb) [#42](https://github.com/znuny/Znuny/pull/42)

--- a/Kernel/Modules/PictureUpload.pm
+++ b/Kernel/Modules/PictureUpload.pm
@@ -187,7 +187,6 @@ sub Run {
     my @AttachmentMeta = $UploadCacheObject->FormIDGetAllFilesMeta(
         FormID => $FormID
     );
-
     ATTACHMENT:
     for my $Attachment (@AttachmentMeta) {
         next ATTACHMENT if ($File{Filename} ne $Attachment->{Filename})

--- a/Kernel/Modules/PictureUpload.pm
+++ b/Kernel/Modules/PictureUpload.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/Modules/PictureUpload.pm
+++ b/Kernel/Modules/PictureUpload.pm
@@ -187,10 +187,11 @@ sub Run {
     my @AttachmentMeta = $UploadCacheObject->FormIDGetAllFilesMeta(
         FormID => $FormID
     );
+
     ATTACHMENT:
     for my $Attachment (@AttachmentMeta) {
         next ATTACHMENT if ($File{Filename} ne $Attachment->{Filename})
-            && !(defined($Attachment->{FilenameOrig}) && ($File{Filename} ne $Attachment->{FilenameOrig}));
+            && !(defined($Attachment->{FilenameOrig}) && ($File{Filename} eq $Attachment->{FilenameOrig}));
         $File{Filename} = $Attachment->{Filename};
         $ContentIDNew = $Attachment->{ContentID};
         last ATTACHMENT;

--- a/Kernel/Modules/PictureUpload.pm
+++ b/Kernel/Modules/PictureUpload.pm
@@ -173,12 +173,18 @@ sub Run {
         . '-'
         . $File{Filename};
 
+    # Clean up filename for name in ContentType; for FormIDAddFile we pass filename without
+    # cleaning it up (need original filename and will clean it up independently).
+    my $FilenameCleanedUp = $Kernel::OM->Get('Kernel::System::Main')->FilenameCleanUp(
+        Filename => $File{Filename},
+    );
+
     # add uploaded file to upload cache
     $UploadCacheObject->FormIDAddFile(
         FormID      => $FormID,
         Filename    => $File{Filename},
         Content     => $File{Content},
-        ContentType => $File{ContentType} . '; name="' . $File{Filename} . '"',
+        ContentType => $File{ContentType} . '; name="' . $FilenameCleanedUp . '"',
         Disposition => 'inline',
     );
 


### PR DESCRIPTION
<!--
  You are amazing! 🚀
  Thanks for contributing to the Znuny community project!
  Please, DO NOT DELETE ANY TEXT from this template (unless instructed)!
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why this pull request should be accepted. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

In ticket compose screen, when you upload inline image from file
(say test.png) using image upload button in ckedit and than upload
same file (test.png) as message attachment, than inline image
will became corrupted (only one file test.png will be present in
upload cache folder when using WebUploadCacheModule
= Kernel::System::Web::UploadCache::FS) and after saving/sending such
article - no inline image will be present.

This mod fixes it by generating random filenames for uploaded images.

Fix [was not applied](https://github.com/OTRS/otrs/pull/1157) to OTRSCE 6 by previous upstream and still exists in Znuny.

Filename in ContentType on image upload is now cleanded up to be compatible with #77 (both should be applied for
filenames alignment).

## Type of change
- '1 - 🐞 bug 🐞'            - Bugfix (non-breaking change which fixes an issue)

## Additional information
<!--
  Details are important and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  Note: Remove this section if not needed.

  If a PR is related to an issue, please use the 'Linked issues' function on the sidebar.
-->
- Problem with long filenames [mentioned by previous upstream](https://github.com/OTRS/otrs/pull/1157#issuecomment-239636262) may be solved (for FS upload cache backend) by applying sparate fix IB#1016067 that was submitted in https://github.com/znuny/Znuny/pull/77
- Related: https://github.com/OTRS/otrs/pull/1157
- Related: https://github.com/znuny/Znuny/pull/77
- Author-Change-Id: IB#1016490


## Checklist
<!--
  Put an '✖️' in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  ❕ - nice to have
  ❗ - required before review
-->

- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [x] Local ZnunyCodePolicy run passes successfully.(❕)
- [x] Local unit tests pass.(❕)
- [ ] GitHub workflow ZnunyCodePolicy passes.(❗)
- [ ] GitHub workflow unit tests pass.(❗)

<!--
  Thank you for contributing ❤

  Znuny @znuny/znuny
-->
