### PR TITLE
Inline image attachments detection fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# 6.0.35 2021-xx-xx
+ - 2021-05-21 Inline image attachments detection fixes.
+
 # 6.0.34 2021-04-21
  - 2021-04-14 Updated jquery-validate from version 1.16.0 to 1.19.3 (CVE-2021-21252).
  - 2021-04-13 Fixed product URL in HTTP Headers. Thanks to Renée Bäcker (@reneeb) [#42](https://github.com/znuny/Znuny/pull/42)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,3 @@
-# 6.0.35 2021-xx-xx
- - 2021-05-21 Inline image attachments detection fixes.
-
 # 6.0.34 2021-04-21
  - 2021-04-14 Updated jquery-validate from version 1.16.0 to 1.19.3 (CVE-2021-21252).
  - 2021-04-13 Fixed product URL in HTTP Headers. Thanks to Renée Bäcker (@reneeb) [#42](https://github.com/znuny/Znuny/pull/42)

--- a/Kernel/Output/HTML/Layout.pm
+++ b/Kernel/Output/HTML/Layout.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/Output/HTML/Layout.pm
+++ b/Kernel/Output/HTML/Layout.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -5107,71 +5108,39 @@ sub RichTextDocumentServe {
         $SessionID = ';' . $Self->{SessionName} . '=' . $Self->{SessionID};
     }
 
-    # replace inline images in content with runtime url to images
+    # Replace inline images (defined with Content-ID or Content-Location)
+    # in content with runtime URL to images.
     my $AttachmentLink = $Self->{Baselink} . $Param{URL};
-    $Param{Data}->{Content} =~ s{
-        (=|"|')cid:(.*?)("|'|>|\/>|\s)
-    }
-    {
-        my $Start= $1;
-        my $ContentID = $2;
-        my $End = $3;
-
-        # improve html quality
-        if ( $Start ne '"' && $Start ne '\'' ) {
-            $Start .= '"';
-        }
-        if ( $End ne '"' && $End ne '\'' ) {
-            $End = '"' . $End;
-        }
-
-        # find matching attachment and replace it with runtime url to image
-        ATTACHMENT_ID:
-        for my $AttachmentID (  sort keys %{ $Param{Attachments} }) {
-            next ATTACHMENT_ID if lc $Param{Attachments}->{$AttachmentID}->{ContentID} ne lc "<$ContentID>";
-            $ContentID = $AttachmentLink . $AttachmentID . $SessionID;
-            last ATTACHMENT_ID;
-        }
-
-        # return new runtime url
-        $Start . $ContentID . $End;
-    }egxi;
-
-    # bug #5053
-    # inline images using Content-Location as identifier instead of Content-ID even RFC2557
-    # http://www.ietf.org/rfc/rfc2557.txt
-
-    # find matching attachment and replace it with runtlime url to image
-    ATTACHMENT:
+    ATTACHMENTID:
     for my $AttachmentID ( sort keys %{ $Param{Attachments} } ) {
-        next ATTACHMENT if !$Param{Attachments}->{$AttachmentID}->{ContentID};
+        next ATTACHMENTID if !$Param{Attachments}->{$AttachmentID}->{ContentID};
 
-        # content id cleanup
+        # Content ID cleanup.
         $Param{Attachments}->{$AttachmentID}->{ContentID} =~ s/^<//;
         $Param{Attachments}->{$AttachmentID}->{ContentID} =~ s/>$//;
 
-        next ATTACHMENT if !$Param{Attachments}->{$AttachmentID}->{ContentID};
+        next ATTACHMENTID if !$Param{Attachments}->{$AttachmentID}->{ContentID};
 
         $Param{Data}->{Content} =~ s{
-        (=|"|')(\Q$Param{Attachments}->{$AttachmentID}->{ContentID}\E)("|'|>|\/>|\s)
-    }
-    {
-        my $Start= $1;
-        my $ContentID = $2;
-        my $End = $3;
-
-        # improve html quality
-        if ( $Start ne '"' && $Start ne '\'' ) {
-            $Start .= '"';
+        (\ssrc\s*=\s*)(["']{0,1}\s*)cid:(\Q$Param{Attachments}->{$AttachmentID}->{ContentID}\E)("|'|>|\/>|\s)
         }
-        if ( $End ne '"' && $End ne '\'' ) {
-            $End = '"' . $End;
-        }
+        {
+            my $PartSrc = $1;
+            my $PartOpenQuot;
+            my $PartContentID = $3;
+            my $PartEnd = $4;
 
-        # return new runtime url
-        $ContentID = $AttachmentLink . $AttachmentID . $SessionID;
-        $Start . $ContentID . $End;
-    }egxi;
+            # Improve HTML quality.
+            if ( $PartEnd ne '"' && $PartEnd ne '\'' ) {
+                $PartEnd = '"' . $PartEnd;
+                $PartOpenQuot = '"';
+            }
+            $PartOpenQuot = $PartEnd if !$PartOpenQuot;
+
+            # Return new runtime URL.
+            $PartContentID = $AttachmentLink . $AttachmentID . $SessionID;
+            $PartSrc . $PartOpenQuot . $PartContentID . $PartEnd;
+        }egxi;
     }
 
     return %{ $Param{Data} };

--- a/Kernel/Output/HTML/Layout/Article.pm
+++ b/Kernel/Output/HTML/Layout/Article.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/System/PostMaster/Filter/DetectAttachment.pm
+++ b/Kernel/System/PostMaster/Filter/DetectAttachment.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/System/PostMaster/Filter/DetectAttachment.pm
+++ b/Kernel/System/PostMaster/Filter/DetectAttachment.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -61,7 +62,7 @@ sub Run {
             )
         {
             my ($ImageID) = ( $Attachment->{ContentID} =~ m{^<(.*)>$}ixms );
-            if ( grep { $_->{Content} =~ m{<img.*src=.*['|"]cid:\Q$ImageID\E['|"].*>}ixms } @Attachments ) {
+            if ( grep { $_->{Content} =~ /(\ssrc\s*=\s*)(["']{0,1}\s*)cid:(\Q$ImageID\E)("|'|>|\/>|\s)/i } @Attachments ) {
                 $AttachmentInline = 1;
             }
         }

--- a/Kernel/System/Ticket/Article/Backend/MIMEBase/Base.pm
+++ b/Kernel/System/Ticket/Article/Backend/MIMEBase/Base.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/System/Ticket/Article/Backend/MIMEBase/Base.pm
+++ b/Kernel/System/Ticket/Article/Backend/MIMEBase/Base.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -216,7 +217,7 @@ sub ArticleAttachmentIndex {
                     my ($ImageID) = ( $File{ContentID} =~ m{^<(.*)>$}ixms );
 
                     # Search in the article body if there is any reference to it.
-                    if ( $HTMLBody{Content} =~ m{<img.+src=['|"]cid:\Q$ImageID\E['|"].*>}ixms ) {
+                    if ( $HTMLBody{Content} =~ /(\ssrc\s*=\s*)(["']{0,1}\s*)cid:(\Q$ImageID\E)("|'|>|\/>|\s)/i ) {
                         push @AttachmentIDsInline, $AttachmentID;
                     }
                 }

--- a/scripts/test/Layout/RichTextDocumentServe.t
+++ b/scripts/test/Layout/RichTextDocumentServe.t
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -53,7 +54,7 @@ my @Tests = (
     {
         Name => '',
         Data => {
-            Content     => "<img border=\"0\" src=\"cid:1234567890ABCDEF\">",
+            Content     => "<img border=\"0\" src = \" \n\tcid:1234567890ABCDEF\">",
             ContentType => 'text/html; charset="iso-8859-1"',
         },
         URL         => 'Action=SomeAction;FileID=',
@@ -64,7 +65,7 @@ my @Tests = (
         },
         Result => {
             Content =>
-                '<img border="0" src="index.pl?Action=SomeAction;FileID=0;SessionID=123">',
+                '<img border="0" src = "index.pl?Action=SomeAction;FileID=0;SessionID=123">',
             ContentType => 'text/html; charset="utf-8"',
         },
     },
@@ -143,7 +144,7 @@ my @Tests = (
     {
         Name => '',
         Data => {
-            Content     => '<img src=\'Untitled%20Attachment\' />',
+            Content     => '<img src=\'CiD:Untitled%20Attachment\' />',
             ContentType => 'text/html; charset="iso-8859-1"',
         },
         URL         => 'Action=SomeAction;FileID=',

--- a/scripts/test/Layout/RichTextDocumentServe.t
+++ b/scripts/test/Layout/RichTextDocumentServe.t
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/scripts/test/LayoutTicket.t
+++ b/scripts/test/LayoutTicket.t
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -54,7 +55,7 @@ my $HTML = '<html>
 <body>
 <b>Test HTML document.</b>
 <img src="cid:1234" border="0">
-<img src="Untitled%20Attachment" border="0">
+<img src="cid:Untitled%20Attachment" border="0">
 Special case from Lotus Notes:
 <img src=cid:_1_09B1841409B1651C003EDE23C325785D border="0">
 </body>

--- a/scripts/test/LayoutTicket.t
+++ b/scripts/test/LayoutTicket.t
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/scripts/test/PostMaster.t
+++ b/scripts/test/PostMaster.t
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -354,7 +355,7 @@ for my $TicketSubjectConfig ( 'Right', 'Left' ) {
             my $UserRand1 = 'example-user' . $Helper->GetRandomID() . '@example.com';
 
             FILE:
-            for my $File (qw(1 2 3 5 6 11 17 18 21 22 23)) {
+            for my $File (qw(1 2 3 5 6 11 17 18 21 22 23 28)) {
 
                 my $NamePrefix = "#$NumberModule $StorageModule $TicketSubjectConfig $File ";
 
@@ -605,6 +606,61 @@ for my $TicketSubjectConfig ( 'Right', 'Left' ) {
                         $MD5,
                         '52f20c90a1f0d8cf3bd415e278992001',
                         $NamePrefix . ' md5 body check',
+                    );
+                }
+
+                if ( $File == 28 ) {
+
+                    # check body
+                    my %Article = $ArticleBackendObject->ArticleGet(
+                        ArticleID     => $ArticleIDs[0],
+                        DynamicFields => 1,
+                    );
+
+                    # check all attachments
+                    my %Index = $ArticleBackendObject->ArticleAttachmentIndex(
+                        ArticleID => $ArticleIDs[0],
+                        ExcludePlainText => 0,
+                        ExcludeHTMLBody => 0,
+                        ExcludeInline => 0,
+                    );
+
+                    $Self->Is(
+                        scalar keys %Index,
+                        3,
+                        $NamePrefix . ' number of attachments check ArticleAttachmentIndex()',
+                    );
+
+                    # check regular attachments
+                    my %Index = $ArticleBackendObject->ArticleAttachmentIndex(
+                        ArticleID => $ArticleIDs[0],
+                        ExcludePlainText => 1,
+                        ExcludeHTMLBody => 1,
+                        ExcludeInline => 1,
+                    );
+
+                    $Self->Is(
+                        scalar keys %Index,
+                        1,
+                        $NamePrefix . ' number of regular attachments check ArticleAttachmentIndex()',
+                    );
+
+                    my %Attachment = $ArticleBackendObject->ArticleAttachment(
+                        ArticleID => $ArticleIDs[0],
+                        FileID    => 3,
+                    );
+
+                    my $MD5 = $MainObject->MD5sum( String => $Attachment{Content} ) || '';
+                    $Self->Is(
+                        $MD5,
+                        'b9e5facb341ca29464001d8e130838ca',
+                        $NamePrefix . ' md5 regular attachment check',
+                    );
+
+                    $Self->Is(
+                        $Attachment{Filename},
+                        'test2.png',
+                        $NamePrefix . ' filename regular attachment check ArticleAttachment()',
                     );
                 }
 

--- a/scripts/test/PostMaster.t
+++ b/scripts/test/PostMaster.t
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/scripts/test/PostMaster.t
+++ b/scripts/test/PostMaster.t
@@ -611,13 +611,13 @@ for my $TicketSubjectConfig ( 'Right', 'Left' ) {
 
                 if ( $File == 28 ) {
 
-                    # check body
+                    # Check body.
                     my %Article = $ArticleBackendObject->ArticleGet(
                         ArticleID     => $ArticleIDs[0],
                         DynamicFields => 1,
                     );
 
-                    # check all attachments
+                    # Check all attachments.
                     my %Index = $ArticleBackendObject->ArticleAttachmentIndex(
                         ArticleID => $ArticleIDs[0],
                         ExcludePlainText => 0,
@@ -631,8 +631,8 @@ for my $TicketSubjectConfig ( 'Right', 'Left' ) {
                         $NamePrefix . ' number of attachments check ArticleAttachmentIndex()',
                     );
 
-                    # check regular attachments
-                    my %Index = $ArticleBackendObject->ArticleAttachmentIndex(
+                    # Check regular attachments.
+                    %Index = $ArticleBackendObject->ArticleAttachmentIndex(
                         ArticleID => $ArticleIDs[0],
                         ExcludePlainText => 1,
                         ExcludeHTMLBody => 1,

--- a/scripts/test/sample/PostMaster/PostMaster-Test28.box
+++ b/scripts/test/sample/PostMaster/PostMaster-Test28.box
@@ -1,0 +1,61 @@
+Date: Wed, 16 Apr 2016 12:00:00 +0200
+From: test <test@host.test>
+To: test <test@host.test>
+Subject: test
+Message-ID: <testmsg1@host.test>
+MIME-Version: 1.0
+Content-Type: multipart/related;
+ boundary="------------38E2FFC460F6F36AA659878B"
+Content-Language: pl
+
+This is a multi-part message in MIME format.
+--------------38E2FFC460F6F36AA659878B
+Content-Type: text/html; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+<html>
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+  </head>
+  <body>
+    <p><font size="-1"><font face="Verdana">test1.png image: <IMG
+            SRC = ' 
+	cid:part1.E5AE6B6E.C188FB97@host1.test'
+alt="" class=""></font></font></p>
+    <p><font size="-1"><font face="Verdana">test2.png image: <img
+            id="CID:part2.4DAB9C65.7AA0767C@host1.test"
+src="https://example.com/test2.png"
+alt="" class=""><br>
+        </font></font></p>
+    <p><br>
+    </p>
+  </body>
+</html>
+
+--------------38E2FFC460F6F36AA659878B
+Content-Type: image/png;
+ name="test1.png"
+Content-Transfer-Encoding: base64
+Content-ID: <part1.E5AE6B6E.C188FB97@host1.test>
+Content-Disposition: inline;
+ filename="test1.png"
+
+iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKAQMAAAC3/F3+AAAABlBMVEX///8AAABVwtN+AAAA
+CXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH3gQYFBgEGpRZowAAAB1pVFh0Q29tbWVudAAA
+AAAAQ3JlYXRlZCB3aXRoIEdJTVBkLmUHAAAAEklEQVQI12NggAEWBgY+MIkEAAGUABckedJ2
+AAAAAElFTkSuQmCC
+--------------38E2FFC460F6F36AA659878B
+Content-Type: image/png;
+ name="test2.png"
+Content-Transfer-Encoding: base64
+Content-ID: <part2.4DAB9C65.7AA0767C@host1.test>
+Content-Disposition: inline;
+ filename="test2.png"
+
+iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAAXNSR0IArs4c6QAAAARnQU1B
+AACxjwv8YQUAAAAJcEhZcwAACxMAAAsTAQCanBgAAAAHdElNRQfeBBgUGAQalFmjAAAAHWlU
+WHRDb21tZW50AAAAAABDcmVhdGVkIHdpdGggR0lNUGQuZQcAAAAySURBVChTY/wPBAxEACYo
+TRBQpvCdrCqUhQAYCmGKMBSDPIMO3sqoQFkIMNh8jQkYGACqFTGhetN9CQAAAABJRU5ErkJg
+gg==
+--------------38E2FFC460F6F36AA659878B--
+


### PR DESCRIPTION
<!--
  You are amazing! 🚀
  Thanks for contributing to the Znuny community project!
  Please, DO NOT DELETE ANY TEXT from this template (unless instructed)!
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why this pull request should be accepted. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Znuny does not recognize inline attachments when formatted with
whitespaces like test1.png in sample e-mail added in this commit:

```
 <IMG
             SRC = '
     cid:part1.E5AE6B6E.C188FB97@host1.test'
 alt="" class="">
```

Thunderbird recognizes it and displays as inline image.

When forwarding HTML messages Znuny skips attachments that have
Content-ID somewhere in HTML message body, not in src attribute.
This may cause poorly attached inline images (like test2.png in sample
e-mail added in this commit) to be absent in forwarded message.

This mod fixes above issues, removes redundant replace operations and
fixes inconsistent CID searching regexps.

## Type of change
- '1 - 🐞 bug 🐞'            - Bugfix (non-breaking change which fixes an issue)

## Additional information
<!--
  Details are important and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  Note: Remove this section if not needed.

  If a PR is related to an issue, please use the 'Linked issues' function on the sidebar.
-->

- Related: https://github.com/OTRS/otrs/pull/1256
- Author-Change-Id: IB#1052680

## Checklist
<!--
  Put an '✖️' in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  ❕ - nice to have
  ❗ - required before review
-->

- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [x] You improved or added new unit tests.(❕)
- [x] Local ZnunyCodePolicy run passes successfully.(❕)
- [x] Local unit tests pass.(❕)
- [ ] GitHub workflow ZnunyCodePolicy passes.(❗)
- [ ] GitHub workflow unit tests pass.(❗)

<!--
  Thank you for contributing ❤

  Znuny @znuny/znuny
-->
