### PR TITLE
Column list validation before saving agent preferences (#84).

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,3 @@
-# 6.0.35 2021-xx-xx
- - 2021-05-25 Column list validation before saving agent preferences.
-
 # 6.0.34 2021-04-21
  - 2021-04-14 Updated jquery-validate from version 1.16.0 to 1.19.3 (CVE-2021-21252).
  - 2021-04-13 Fixed product URL in HTTP Headers. Thanks to Renée Bäcker (@reneeb) [#42](https://github.com/znuny/Znuny/pull/42)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# 6.0.35 2021-xx-xx
+ - 2021-05-25 Column list validation before saving agent preferences.
+
 # 6.0.34 2021-04-21
  - 2021-04-14 Updated jquery-validate from version 1.16.0 to 1.19.3 (CVE-2021-21252).
  - 2021-04-13 Fixed product URL in HTTP Headers. Thanks to Renée Bäcker (@reneeb) [#42](https://github.com/znuny/Znuny/pull/42)

--- a/Kernel/Output/HTML/Preferences/ColumnFilters.pm
+++ b/Kernel/Output/HTML/Preferences/ColumnFilters.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -61,10 +62,23 @@ sub Run {
 
         # pref update db
         if ( !$Kernel::OM->Get('Kernel::Config')->Get('DemoSystem') ) {
+
+            my %Seen;
+            my @ColumnsUnique;
+            COLUMN:
+            for my $Column ( @{ $Param{GetParam}->{$Key} } ) {
+
+                # Skip duplicates.
+                next COLUMN if $Seen{$Column};
+                $Seen{$Column} = 1;
+
+                push @ColumnsUnique, $Column;
+            }
+
             $Kernel::OM->Get('Kernel::System::User')->SetPreferences(
                 UserID => $Param{UserData}->{UserID},
                 Key    => $Key . '-' . $FilterAction,
-                Value  => $Kernel::OM->Get('Kernel::System::JSON')->Encode( Data => $Param{GetParam}->{$Key} ),
+                Value  => $Kernel::OM->Get('Kernel::System::JSON')->Encode( Data => \@ColumnsUnique ),
             );
         }
     }

--- a/Kernel/Output/HTML/Preferences/ColumnFilters.pm
+++ b/Kernel/Output/HTML/Preferences/ColumnFilters.pm
@@ -64,23 +64,23 @@ sub Run {
         for my $Key ( sort keys %{ $Param{GetParam} } ) {
 
             # We require non-empty list of column names - ignore antyhing else.
-            next KEY if !( $Param{GetParam}->{$Key} && IsArrayRefWithData( $Param{GetParam}->{$Key} ) );
+            next KEY if !$Param{GetParam}->{$Key};
+            next KEY if !IsArrayRefWithData($Param{GetParam}->{$Key});
 
             # Remove column name duplicates from list preserving column order.
             my %SeenColumnNames;
-            my @DeduplicatedColumnNameArray;
-            COLUMN_NAME:
+            my @UniqueColumnNames;
+            COLUMNNAME:
             for my $ColumnName ( @{ $Param{GetParam}->{$Key} } ) {
-                next COLUMN_NAME if $SeenColumnNames{$ColumnName};
+                next COLUMNNAME if $SeenColumnNames{$ColumnName};
                 $SeenColumnNames{$ColumnName} = 1;
-                push @DeduplicatedColumnNameArray, $ColumnName;
+                push @UniqueColumnNames, $ColumnName;
             }
 
-            # Update list in DB.
             $Kernel::OM->Get('Kernel::System::User')->SetPreferences(
                 UserID => $Param{UserData}->{UserID},
                 Key    => $Key . '-' . $FilterAction,
-                Value  => $Kernel::OM->Get('Kernel::System::JSON')->Encode( Data => \@DeduplicatedColumnNameArray ),
+                Value  => $Kernel::OM->Get('Kernel::System::JSON')->Encode( Data => \@UniqueColumnNames ),
             );
         }
     }


### PR DESCRIPTION
<!--
  You are amazing! 🚀
  Thanks for contributing to the Znuny community project!
  Please, DO NOT DELETE ANY TEXT from this template (unless instructed)!
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why this pull request should be accepted. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


It was noticed in OTRS 3.3, that some agents managed to save their column
filter preferences with duplikcated column names i.e.

```
    mysql -e 'SELECT * FROM user_preferences where length(preferences_value)>100' otrs
    [...]
    5       UserFilterColumnsEnabled-AgentTicketQueue       ["TicketNumber","Title","State","Lock","Queue","Owner","Age","Changed","CustomerID","Lock","Queue","CustomerID","TicketNumber", [...], "TicketNumber","Age","Title","State","Lock","Queue","CustomerID"]
```

The whole preference string was over 9kB long (all filled with duplicated
column list as above) and caused apache RAM consumption problems (removing
this record from DB was necessary to avoid out of memory on OTRS
application server). The problem was not reproducible and the cause of
the problem has not been identified (might be some kind of race condition
or web browser bug).

Same problem still exists in Znuny rel-6_0 - to simulate misbehaving
client apply patch

```diff -Nur a/var/httpd/htdocs/js/Core.Agent.Overview.js b/var/httpd/htdocs/js/Core.Agent.Overview.js
 --- a/var/httpd/htdocs/js/Core.Agent.Overview.js<->2021-05-15 16:03:56.586105278 +0200
 +++ b/var/httpd/htdocs/js/Core.Agent.Overview.js>2021-05-25 14:18:25.375359470 +0200
 @@ -83,6 +83,7 @@
                                      // if e.g. the save button is clicked multiple times
                                      if (!$('#' + Core.App.EscapeSelector(FieldID)).length) {
                                          $('<input name="UserFilterColumnsEnabled" type="hidden" />').attr('id', FieldID).val($(this).attr('data-fieldname')).appendTo($ListContainer.closest('div'));
 +                                        $('<input name="UserFilterColumnsEnabled" type="hidden" />').attr('id', FieldID).val($(this).attr('data-fieldname')).appendTo($ListContainer.closest('div'));
                                      }
                                  });
                              }
```

and change column order in Action=AgentTicketQueue in Small (S) mode.

Regardless of cause Znuny should not allow to save duplicated columns
(i.e. to prevent attacks).

This mod adds validation of column list just before saving preferences
duplicates are removed which should protect Znuny against the problem
described above.

## Type of change
- '1 - 🐞 bug 🐞'            - Bugfix (non-breaking change which fixes an issue)

## Additional information
<!--
  Details are important and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  Note: Remove this section if not needed.

  If a PR is related to an issue, please use the 'Linked issues' function on the sidebar.
-->
- Related: https://github.com/OTRS/otrs/pull/1507
- Author-Change-Id: IB#1058144

## Checklist
<!--
  Put an 'x' in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  ❕ - nice to have
  ❗ - required before review
-->

- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [x] Local ZnunyCodePolicy run passes successfully.(❕)
- [x] Local unit tests pass.(❕)
- [x] GitHub workflow ZnunyCodePolicy passes.(❗)
- [x] GitHub workflow unit tests pass.(❗)

<!--
  Thank you for contributing ❤

  Znuny @znuny/znuny
-->
