### PR TITLE
Do not warn agents about empty article subjects by default (#88).

### DIFF
--- a/Kernel/Modules/AgentTicketCompose.pm
+++ b/Kernel/Modules/AgentTicketCompose.pm
@@ -1311,10 +1311,6 @@ sub Run {
 
         my $Empty = !length $CleanedSubject;
 
-        $Kernel::OM->Get('Kernel::System::Log')
-            ->Log( Priority => error => Message =>
-                $Kernel::OM->Get('Kernel::System::Main')->Dump( [ $OldSubject, $CleanedSubject, $Empty, ] ) );
-
         my $JSON = $LayoutObject->JSONEncode(
             Data => {
                 Empty   => $Empty ? 1 : 0,

--- a/Kernel/Modules/AgentTicketCompose.pm
+++ b/Kernel/Modules/AgentTicketCompose.pm
@@ -1302,11 +1302,11 @@ sub Run {
             'Article subject will be empty if the subject contains only the ticket hook!'
         );
 
-        my $OldSubject = $ParamObject->GetParam( Param => 'Subject' );
+        my $Subject = $ParamObject->GetParam( Param => 'Subject' );
 
         my $CleanedSubject = $TicketObject->TicketSubjectClean(
             TicketNumber => $Ticket{TicketNumber},
-            Subject      => $OldSubject,
+            Subject      => $Subject,
         );
 
         my $Empty = !length $CleanedSubject;

--- a/Kernel/Modules/AgentTicketCompose.pm
+++ b/Kernel/Modules/AgentTicketCompose.pm
@@ -1295,18 +1295,45 @@ sub Run {
             NoCache     => 1,
         );
     }
+    elsif ( $Self->{Subaction} eq 'CheckSubject' ) {
+
+        # Inform a user that article subject will be empty if contains only the ticket hook (if nothing is modified).
+        my $Message = $LayoutObject->{LanguageObject}->Translate(
+            'Article subject will be empty if the subject contains only the ticket hook!'
+        );
+
+        my $OldSubject = $ParamObject->GetParam( Param => 'Subject' );
+
+        my $CleanedSubject = $TicketObject->TicketSubjectClean(
+            TicketNumber => $Ticket{TicketNumber},
+            Subject      => $OldSubject,
+        );
+
+        my $Empty = !length $CleanedSubject;
+
+        $Kernel::OM->Get('Kernel::System::Log')
+            ->Log( Priority => error => Message =>
+                $Kernel::OM->Get('Kernel::System::Main')->Dump( [ $OldSubject, $CleanedSubject, $Empty, ] ) );
+
+        my $JSON = $LayoutObject->JSONEncode(
+            Data => {
+                Empty   => $Empty ? 1 : 0,
+                Message => $Message,
+            }
+        );
+
+        return $LayoutObject->Attachment(
+            ContentType => 'application/json; charset=' . $LayoutObject->{Charset},
+            Content     => $JSON,
+            Type        => 'inline',
+            NoCache     => 1,
+        );
+    }
     else {
         my $Output = $LayoutObject->Header(
             Value     => $Ticket{TicketNumber},
             Type      => 'Small',
             BodyClass => 'Popup',
-        );
-
-        # Inform a user that article subject will be empty if contains only the ticket hook (if nothing is modified).
-        $Output .= $LayoutObject->Notify(
-            Data => $LayoutObject->{LanguageObject}->Translate(
-                'Article subject will be empty if the subject contains only the ticket hook!'
-            ),
         );
 
         # get std attachment object

--- a/var/httpd/htdocs/js/Core.Agent.TicketCompose.js
+++ b/var/httpd/htdocs/js/Core.Agent.TicketCompose.js
@@ -44,6 +44,10 @@ Core.Agent.TicketCompose = (function (TargetNS) {
             Core.AJAX.FormUpdate($('#ComposeTicket'), 'AJAXUpdate', 'StateID', Core.Config.Get('DynamicFieldNames'));
         });
 
+        // check subject
+        CheckSubject();
+        $('#Subject').on('change', CheckSubject);
+
         // add 'To' customer users
         if (typeof EmailAddressesTo !== 'undefined') {
             EmailAddressesTo.forEach(function(ToCustomer) {
@@ -67,6 +71,27 @@ Core.Agent.TicketCompose = (function (TargetNS) {
             });
         }
     };
+
+    function CheckSubject () {
+        var CurrentSubject = $('#Subject').val();
+        $('#SubjectWarning').remove();
+
+        $.ajax({
+            url: Core.Config.Get('Baselink'),
+            type: 'POST',
+            data: {
+                Action: Core.Config.Get('Action'),
+                Subaction: 'CheckSubject',
+                Subject: CurrentSubject,
+                TicketID: $('input[name=TicketID]').val(),
+            },
+            success : function(Response) {
+                if (Response.Empty) {
+                    $('#AppWrapper').prepend('<div class="MessageBox Notice" id="SubjectWarning"><p>' + Response.Message + '</div>');
+                }
+            }
+        });
+    }
 
     Core.Init.RegisterNamespace(TargetNS, 'APP_MODULE');
 


### PR DESCRIPTION
<!--
  You are amazing! 🚀
  Thanks for contributing to the Znuny community project!
  Please, DO NOT DELETE ANY TEXT from this template (unless instructed)!

### Licensing, copyright and credits

Znuny is an open fork of an existing software. So we have to respect the already given copyright of the original creators.

New files will be licensed using the AGPL Version 3. If you contribute code to the Znuny project you will get mentioned in the pull request incl. the commit, in CHANGES.md and in AUTHORS.md. We will not mention you in the file you provided or changed. Your work is highly appreciated and acknowledged but you contribute it to the project and your copyright will pass on to the fork itself.
-->

## Proposed change

When an agent wants to reply to a ticket, they get a warning about empty article subjects when the mail only contains the ticket hook. This is annoying as the subject usually doesn't contain only the ticket hook.

This change implements a new subaction for AgentTicketCompose where the subject is checked. And in the JavaScript code this subaction is called when the dialog is opened and when the subject is changed. And the warning is shown when TicketSubjectClean() returns an empty subject (and the new subaction returns a value that the subject would be empty).

This new subaction has the nice effect, that a solution for znuny/znuny-feature-requests#19 would be recognized as well without any further code change.

## Type of change

- '1 - 🐞 bug 🐞'            - Bugfix (non-breaking change which fixes an issue)


## Additional information

- This PR is related to issue: znuny/Znuny#34 

## Checklist
<!--
  Put an 'x' in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  ❕ - nice to have
  ❗ - required before review
-->

- [X] The code change is tested and works locally.(❗)
- [X] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [X] Local ZnunyCodePolicy run passes successfully.(❕)
- [ ] Local unit tests pass.(❕)
- [x] GitHub workflow ZnunyCodePolicy passes.(❗)
- [x] GitHub workflow unit tests pass.(❗)

<!--
  Thank you for contributing ❤

  Znuny @znuny/znuny
-->
