### PR TITLE
Added SysConfig option to enable week numbers in the datepicker widget.

### DIFF
--- a/Kernel/Config/Files/XML/Framework.xml
+++ b/Kernel/Config/Files/XML/Framework.xml
@@ -9015,4 +9015,11 @@ via the Preferences button after logging in.
             </Array>
         </Value>
     </Setting>
+    <Setting Name="Datepicker::ShowWeek" Required="0" Valid="1">
+        <Description Translatable="1">Activates week number for datepickers.</Description>
+        <Navigation>Frontend::Agent</Navigation>
+        <Value>
+            <Item ValueType="Checkbox" ValueRegex="">0</Item>
+        </Value>
+    </Setting>
 </otrs_config>

--- a/Kernel/Output/HTML/Layout.pm
+++ b/Kernel/Output/HTML/Layout.pm
@@ -1658,6 +1658,7 @@ sub Footer {
         InputFieldsActivated           => $ConfigObject->Get('ModernizeFormFields'),
         OTRSBusinessIsInstalled        => $Param{OTRSBusinessIsInstalled},
         VideoChatEnabled               => $Param{VideoChatEnabled},
+        DatepickerShowWeek             => $ConfigObject->Get('Datepicker::ShowWeek') || 0,
         PendingStateIDs                => \@PendingStateIDs,
         CheckSearchStringsForStopWords => (
             $ConfigObject->Get('Ticket::SearchIndex::WarnOnStopWordUsage')

--- a/var/httpd/htdocs/js/Core.UI.Datepicker.js
+++ b/var/httpd/htdocs/js/Core.UI.Datepicker.js
@@ -173,6 +173,7 @@ Core.UI.Datepicker = (function (TargetNS) {
             nextText: Core.Language.Translate('Next'),
             firstDay: Element.WeekDayStart,
             showMonthAfterYear: 0,
+            showWeek: (Core.Config.Get('DatepickerShowWeek') == 1 ? true : false),
             monthNames: [
                 Core.Language.Translate('Jan'),
                 Core.Language.Translate('Feb'),


### PR DESCRIPTION
<!--
  You are amazing! 🚀
  Thanks for contributing to the Znuny community project!
  Please, DO NOT DELETE ANY TEXT from this template (unless instructed)!

### Licensing, copyright and credits

Znuny is an open fork of an existing software. So we have to respect the already given copyright of the original creators.

New files will be licensed using the AGPL Version 3. If you contribute code to the Znuny project you will get mentioned in the pull request incl. the commit, in CHANGES.md and in AUTHORS.md. We will not mention you in the file you provided or changed. Your work is highly appreciated and acknowledged but you contribute it to the project and your copyright will pass on to the fork itself.
-->

## Proposed change

Currently the datepicker (e.g. to select the pending reminder date/time) shows only the month and its dates. 

![image](https://user-images.githubusercontent.com/144096/120812832-a701d180-c54d-11eb-8051-1e0d954574ee.png)

But in many environments people talk about "this has to be done in week 22...". This change adds a new sysconfig option and when this option is enabled, the datepicker also shows the weeknumber

![image](https://user-images.githubusercontent.com/144096/120813005-cac51780-c54d-11eb-94d7-3ab8825efa91.png)

## Type of change

- '1 - 🚀 feature'           - New feature (which adds functionality to an existing integration)


## Checklist
<!--
  Put an 'x' in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  ❕ - nice to have
  ❗ - required before review
-->

- [X] The code change is tested and works locally.(❗)
- [X] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [ ] Local ZnunyCodePolicy run passes successfully.(❕)
- [ ] Local unit tests pass.(❕)
- [x] GitHub workflow ZnunyCodePolicy passes.(❗)
- [x] GitHub workflow unit tests pass.(❗)

<!--
  Thank you for contributing ❤

  Znuny @znuny/znuny
-->
