### PR TITLE
Use ticket title as the default appointment title.

### DIFF
--- a/Kernel/Modules/AgentAppointmentEdit.pm
+++ b/Kernel/Modules/AgentAppointmentEdit.pm
@@ -975,9 +975,15 @@ sub Run {
 
                 # add possible links
                 for my $LinkID (@LinkArray) {
+                    my $LinkData = $ResultList->{$LinkID};
+
+                    if ( $GetParam{ObjectID} && !defined $Appointment{Title} && ref $LinkData ) {
+                        $Appointment{Title} = $LinkData->{Title};
+                    }
+
                     push @{ $Param{PluginData}->{ $GetParam{PluginKey} } }, {
                         LinkID   => $LinkID,
-                        LinkName => $ResultList->{$LinkID},
+                        LinkName => ( ref $LinkData ? $LinkData->{Subject} : $LinkData ),
                         LinkURL  => sprintf(
                             $Param{PluginList}->{ $GetParam{PluginKey} }->{PluginURL},
                             $LinkID

--- a/Kernel/Modules/AgentAppointmentPluginSearch.pm
+++ b/Kernel/Modules/AgentAppointmentPluginSearch.pm
@@ -71,9 +71,11 @@ sub Run {
         keys %{$ResultList}
         )
     {
+
+        my $ObjectData = $ResultList->{$ObjectID};
         push @Data, {
             Key   => $ObjectID,
-            Value => $ResultList->{$ObjectID},
+            Value => ref $ObjectData ? $ObjectData->{Subject} : $ObjectData,
         };
 
         $MaxResultCount--;

--- a/Kernel/System/Calendar/Plugin/Ticket.pm
+++ b/Kernel/System/Calendar/Plugin/Ticket.pm
@@ -229,7 +229,10 @@ sub Search {
         next TICKET if !%Ticket;
 
         # generate the ticket information string
-        $ResultList{ $Ticket{TicketID} } = $Ticket{TicketNumber} . ' ' . $Ticket{Title};
+        $ResultList{ $Ticket{TicketID} } = {
+            Subject => $Ticket{TicketNumber} . ' ' . $Ticket{Title},
+            Title   => $Ticket{Title},
+        };
     }
 
     return \%ResultList;

--- a/scripts/test/Calendar/Plugin.t
+++ b/scripts/test/Calendar/Plugin.t
@@ -189,7 +189,10 @@ if ($PluginKeyTicket) {
     $Self->IsDeeply(
         $ResultList,
         {
-            $TicketID => "$TicketNumber Test Ticket $RandomID",
+            $TicketID => {
+                Subject => "$TicketNumber Test Ticket $RandomID",
+                Title   => "Test Ticket $RandomID",
+            },
         },
         'PluginSearch() - Search results (by ticket number)'
     );
@@ -204,7 +207,10 @@ if ($PluginKeyTicket) {
     $Self->IsDeeply(
         $ResultList,
         {
-            $TicketID => "$TicketNumber Test Ticket $RandomID",
+            $TicketID => {
+                Subject => "$TicketNumber Test Ticket $RandomID",
+                Title   => 'Test Ticket ' . $RandomID,
+            },
         },
         'PluginSearch() - Search results (by ticket ID)'
     );


### PR DESCRIPTION
<!--
  You are amazing! 🚀
  Thanks for contributing to the Znuny community project!
  Please, DO NOT DELETE ANY TEXT from this template (unless instructed)!

### Licensing, copyright and credits

Znuny is an open fork of an existing software. So we have to respect the already given copyright of the original creators.

New files will be licensed using the AGPL Version 3. If you contribute code to the Znuny project you will get mentioned in the pull request incl. the commit, in CHANGES.md and in AUTHORS.md. We will not mention you in the file you provided or changed. Your work is highly appreciated and acknowledged but you contribute it to the project and your copyright will pass on to the fork itself.
-->

## Proposed change

When you want to create a new appointment from a ticket, the appointment title is empty. This change add support for calendar plugins that return a more "complex" datastructure for the method Search(). More complex means that a hashref is returned for each item instead of a string. That way, a default title can be set with whatever the calendar plugin returns in the hashref for the key "Title".

This PR also changed the Search() method for the Ticket plugin to return the ticket title as a default appointment title.

The changes keep backwards compatibility so that other existing plugins still work.


## Type of change

- '1 - 🚀 feature'           - New feature (which adds functionality to an existing integration)


## Checklist
<!--
  Put an 'x' in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  ❕ - nice to have
  ❗ - required before review
-->

- [X] The code change is tested and works locally.(❗)
- [X] There is no commented out code in this PR.(❕)
- [X] You improved or added new unit tests.(❕)
- [X] Local ZnunyCodePolicy run passes successfully.(❕)
- [ ] Local unit tests pass.(❕)
- [x] GitHub workflow ZnunyCodePolicy passes.(❗)
- [x] GitHub workflow unit tests pass.(❗)

<!--
  Thank you for contributing ❤

  Znuny @znuny/znuny
-->
