### PR TITLE
Postmaster decrypt filter fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,3 @@
-# 6.0.36 2021-xx-xx
- - 2021-06-07 Postmaster decrypt filter fixes.
-
 # 6.0.35 2021-06-02
  - 2021-05-28 Improved StorageSwitch command to be more flexible (#27). Thanks to Renée Bäcker (@reneeb). [#27](https://github.com/znuny/Znuny/pull/27)
  - 2021-05-26 Changed autocomplete to 'new-password' (#64). Thanks to maxence (@tipue-dev) and Thijs Kinkhorst (@thijskh) [#64](https://github.com/znuny/Znuny/pull/64)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# 6.0.36 2021-xx-xx
+ - 2021-06-07 Postmaster decrypt filter fixes.
+
 # 6.0.35 2021-06-02
  - 2021-05-28 Improved StorageSwitch command to be more flexible (#27). Thanks to Renée Bäcker (@reneeb). [#27](https://github.com/znuny/Znuny/pull/27)
  - 2021-05-26 Changed autocomplete to 'new-password' (#64). Thanks to maxence (@tipue-dev) and Thijs Kinkhorst (@thijskh) [#64](https://github.com/znuny/Znuny/pull/64)

--- a/Kernel/Config/Files/XML/Ticket.xml
+++ b/Kernel/Config/Files/XML/Ticket.xml
@@ -11563,7 +11563,7 @@ Thanks for your help!
         </Value>
     </Setting>
     <Setting Name="PostMaster::PreFilterModule###000-DecryptBody" Required="0" Valid="0">
-        <Description Translatable="1">Module to filter encrypted bodies of incoming messages.</Description>
+        <Description Translatable="1">Module to allow filtering bodies of incoming messages (encrypted and not encrypted) using X-OTRS-BodyDecrypted (note: Body in postmaster filter definition doesn't work for encrypted messages). For encrypted messages article search index is not created on article creation but when article is opened for the first time (decrypted) in application. Enabling StoreDecryptedBody allows to create search index on article creation but !!!WARNING!!! when StoreDecryptedBody is enabled, attachments from encrypted messages won't be extracted from message and visible in application web panel! Enable StoreDecryptedBody only if you're ABSOLUTELY SURE it won't hurt your communication (i.e. encrypted messages won't have attachments). Message decription flow should be fixed in the future application versions probably, to preserve attachments in UI also when StoreDecryptedBody is enabled.</Description>
         <Navigation>Core::Email::PostMaster</Navigation>
         <Value>
             <Hash>

--- a/Kernel/System/PostMaster/Filter/Decrypt.pm
+++ b/Kernel/System/PostMaster/Filter/Decrypt.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you


### PR DESCRIPTION
<!--
  You are amazing! 🚀
  Thanks for contributing to the Znuny community project!
  Please, DO NOT DELETE ANY TEXT from this template (unless instructed)!

### Licensing, copyright and credits

Znuny is an open fork of an existing software. So we have to respect the already given copyright of the original creators.

New files will be licensed using the AGPL Version 3. If you contribute code to the Znuny project you will get mentioned in the pull request incl. the commit, in CHANGES.md and in AUTHORS.md. We will not mention you in the file you provided or changed. Your work is highly appreciated and acknowledged but you contribute it to the project and your copyright will pass on to the fork itself.
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why this pull request should be accepted. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This mod solves the following bugs found in Kernel::System::PostMaster::Filter::Decrypt: 

* Decryption key searching was broken (was using From address); searching algo was adjusted in the same way as Kernel/Output/HTML/ArticleCheck/SMIME.pm work (i.e. searchich recipient e-mail address in more headers).

* It was tested that enabling `StoreDecryptedBody` causes attachments from encrypted messages to be missing in application web UI (Kernel/Output/HTML/ArticleCheck/SMIME.pm does not try to extract it because it wrongly thinks that message was already fully decrypted when body is decrypted). This mod adds warnings to `StoreDecryptedBody` description about this dangerous behavior but doesn't fix the issue (whole message decryption flow should be fixed probably - will be submitted as separate issue).

* `X-OTRS-BodyDecrypted` was populated only for encrypted messages; to filter all messages against body, one had to define two similar filters: one for encrypted messages (using X-OTRS-BodyDecrypted) and one for unencrypted messages (using Body); this mod populates X-OTRS-BodyDecrypted also for unencrypted messages so now its possible to define only one postmaster filter (using X-OTRS-BodyDecrypted) for both kinds of messages.

## Type of change
- '1 - 🐞 bug 🐞'            - Bugfix (non-breaking change which fixes an issue)

## Breaking change
<!--
  If your PR contains a breaking change, it is important
  to tell what breaks, how to make it work again and why it is necessary.
  This piece of text is published with the release notes, so it helps if you
  write it for the users, not the maintainer.
  Note: Remove this section if this PR is NOT a breaking change.
-->
After this mod X-OTRS-BodyDecrypted is populated with body also for unencrypted messages (was only populated with decrypted body of encrypted messages and empty for unencrypted messages).

## Additional information
<!--
  Details are important and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  Note: Remove this section if not needed.

  If a PR is related to an issue, please use the 'Linked issues' function on the sidebar.
-->
Author-Change-Id: IB#1105161

## Checklist
<!--
  Put an 'x' in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  ❕ - nice to have
  ❗ - required before review
-->

- [x] The code change is tested and works locally.(❗)
- [ ] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [x] Local ZnunyCodePolicy run passes successfully.(❕)
- [x] Local unit tests pass.(❕)
- [ ] GitHub workflow ZnunyCodePolicy passes.(❗)
- [ ] GitHub workflow unit tests pass.(❗)

<!--
  Thank you for contributing ❤

  Znuny @znuny/znuny
-->
