### PR TITLE
Added optional Feature "DontSkipMe" to TransitionAction TicketCreate

### DIFF
--- a/Kernel/System/ProcessManagement/TransitionAction/TicketCreate.pm
+++ b/Kernel/System/ProcessManagement/TransitionAction/TicketCreate.pm
@@ -81,6 +81,7 @@ sub new {
             Owner         => 'someuserlogin',    # or OwnerID => 123
 
             # ticket optional:
+            DontSkipMe      => "1", # optional, without given value DontSkipMe is 1
             TN              => $TicketObject->TicketCreateNumber(), # optional
             Type            => 'Incident',            # or TypeID => 1, not required
             Service         => 'Service A',           # or ServiceID => 1, not required
@@ -151,7 +152,29 @@ sub Run {
             );
         }
     }
-
+    
+    # check for DontSkipMe
+    my $DontSkipMe;
+    if( defined( $Param{Config}->{DontSkipMe}) )
+    {
+        $DontSkipMe = $Param{Config}->{DontSkipMe};
+    }
+    else
+    {
+        $DontSkipMe = 1;
+    }
+    
+    if( !$DontSkipMe )
+    {
+        $Kernel::OM->Get('Kernel::System::Log')->Log(
+            Priority => 'info',
+            Message  => $CommonMessage
+                . "Skipped Create of New Ticket from Ticket: "
+                . $Param{Ticket}->{TicketID} . '!',
+        );
+        return;
+    }
+    
     # collect ticket params
     my %TicketParam;
     for my $Attribute (


### PR DESCRIPTION
This makes it possible to put several TransitionActions of the type TicketCreate into one transition and to process them depending on e.g. checkboxes. Example: several dynamic fields of the type Checkbox - each checkbox is to cause a split ticket to be created. Currently, wild transitions have to be built to solve this problem. With this change you can simply paste the value of the checkbox <OTRS_TICKET_DynamicField_Checkbox1> to the config parameter DontSkipMe and get the desired result.

<!--
  You are amazing! 🚀
  Thanks for contributing to the Znuny community project!
  Please, DO NOT DELETE ANY TEXT from this template (unless instructed)!

### Licensing, copyright and credits

Znuny is an open fork of an existing software. So we have to respect the already given copyright of the original creators.

New files will be licensed using the AGPL Version 3. If you contribute code to the Znuny project you will get mentioned in the pull request incl. the commit, in CHANGES.md and in AUTHORS.md. We will not mention you in the file you provided or changed. Your work is highly appreciated and acknowledged but you contribute it to the project and your copyright will pass on to the fork itself.
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why this pull request should be accepted. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Example: several dynamic fields of the type Checkbox - each checkbox is to cause a split ticket to be created. Currently, wild transitions have to be built to solve this problem. With this change you can simply paste the value of the checkbox <OTRS_TICKET_DynamicField_Checkbox1> to the config parameter DontSkipMe and get the described result without building wild Transitions.

<!--
## Type of change
  What type of change does your PR introduce to Znuny?
  NOTE: Please add only one label with a starting '1 - ' to this PR!
  If your PR requires multiple labels to be applied, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster for the code review.

- '1 - 🆙 dependency upgrade - Dependency upgrade (e.g. libraries)
- '1 - 🐞 bug 🐞'            - Bugfix (non-breaking change which fixes an issue)
- '1 - 💎 code quality'      - Code quality improvements to existing code or addition of unit tests
- '1 - 🚀 feature'           - New feature (which adds functionality to an existing integration)
- '1 - ...'

-->
- '1 - 🚀 feature - Added optional Feature "DontSkipMe" to TransitionAction TicketCreate'


## Additional information
<!--
  Details are important and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  Note: Remove this section if not needed.

  If a PR is related to an issue, please use the 'Linked issues' function on the sidebar.
-->

<!--
- This PR is related to PR: #
- ...
-->

## Checklist
<!--
  Put an 'x' in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  ❕ - nice to have
  ❗ - required before review
-->

- [X] The code change is tested and works locally.(❗)
- [X] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [ ] Local ZnunyCodePolicy run passes successfully.(❕)
- [ ] Local unit tests pass.(❕)
- [ ] GitHub workflow ZnunyCodePolicy passes.(❗)
- [ ] GitHub workflow unit tests pass.(❗)

<!--
  Thank you for contributing ❤

  Znuny @znuny/znuny
-->
