### PR TITLE
Fixed log flooding via Net::LDAP. Reduction of LDAP_SIZELIMIT_EXCEEDED messages.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# 6.0.39 2021-??-??
+ - 2021-12-15 Log flooding with less important messages fixed.
+
 # 6.0.38 2021-10-27
  - 2021-10-21 Fixed error log message for missing days in Kernel::System::SysConfig::ValueType::WorkingHours::ModifiedValueGet(). [#122](https://github.com/znuny/Znuny/issues/122)
  - 2021-10-21 Fixed "Need Ticket ID" error when switching templates in AgentTicketCommon modules. [#127](https://github.com/znuny/Znuny/issues/127)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,3 @@
-# 6.0.39 2021-??-??
- - 2021-12-15 Log flooding with less important messages fixed.
-
 # 6.0.38 2021-10-27
  - 2021-10-21 Fixed error log message for missing days in Kernel::System::SysConfig::ValueType::WorkingHours::ModifiedValueGet(). [#122](https://github.com/znuny/Znuny/issues/122)
  - 2021-10-21 Fixed "Need Ticket ID" error when switching templates in AgentTicketCommon modules. [#127](https://github.com/znuny/Znuny/issues/127)

--- a/Kernel/System/CustomerUser/LDAP.pm
+++ b/Kernel/System/CustomerUser/LDAP.pm
@@ -1067,10 +1067,22 @@ sub CustomerSearchDetail {
     );
 
     if ( $ResultSearch->code() ) {
-        $Kernel::OM->Get('Kernel::System::Log')->Log(
-            Priority => 'error',
-            Message  => $ResultSearch->error(),
-        );
+        if ( $ResultSearch->code() == 4 ) {
+
+            # Result code 4 (LDAP_SIZELIMIT_EXCEEDED) is normal if there
+            # are more items in LDAP than search limit defined in OTRS or
+            # in LDAP server. Avoid spamming logs with such errors.
+            $Kernel::OM->Get('Kernel::System::Log')->Log(
+                Priority => 'debug',
+                Message  => 'LDAP size limit exceeded (' . $ResultSearch->error() . ').',
+            );
+        }
+        else {
+            $Kernel::OM->Get('Kernel::System::Log')->Log(
+                Priority => 'error',
+                Message  => 'Search failed! ' . $ResultSearch->error(),
+            );
+        }
     }
 
     my @TmpCustomerUsers;

--- a/Kernel/System/CustomerUser/LDAP.pm
+++ b/Kernel/System/CustomerUser/LDAP.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021-2022 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -13,6 +14,7 @@ use strict;
 use warnings;
 
 use Net::LDAP;
+use Net::LDAP qw(LDAP_SIZELIMIT_EXCEEDED);
 use Net::LDAP::Util qw(escape_filter_value);
 
 use Kernel::System::VariableCheck qw(:all);
@@ -259,10 +261,10 @@ sub CustomerName {
     );
 
     if ( $Result->code() ) {
-        if ( $Result->code() == 4 ) {
+        if ( $Result->code() == LDAP_SIZELIMIT_EXCEEDED ) {
 
-            # Result code 4 (LDAP_SIZELIMIT_EXCEEDED) is normal if there
-            # are more items in LDAP than search limit defined in OTRS or
+            # LDAP_SIZELIMIT_EXCEEDED result is ok if there
+            # are more items in LDAP than search limit defined in Znuny or
             # in LDAP server. Avoid spamming logs with such errors.
             $Kernel::OM->Get('Kernel::System::Log')->Log(
                 Priority => 'debug',
@@ -497,10 +499,10 @@ sub CustomerSearch {
 
     # log ldap errors
     if ( $Result->code() ) {
-        if ( $Result->code() == 4 ) {
+        if ( $Result->code() == LDAP_SIZELIMIT_EXCEEDED ) {
 
-            # Result code 4 (LDAP_SIZELIMIT_EXCEEDED) is normal if there
-            # are more items in LDAP than search limit defined in OTRS or
+            # LDAP_SIZELIMIT_EXCEEDED result is ok if there
+            # are more items in LDAP than search limit defined in Znuny or
             # in LDAP server. Avoid spamming logs with such errors.
             $Kernel::OM->Get('Kernel::System::Log')->Log(
                 Priority => 'debug',
@@ -1067,10 +1069,10 @@ sub CustomerSearchDetail {
     );
 
     if ( $ResultSearch->code() ) {
-        if ( $ResultSearch->code() == 4 ) {
+        if ( $ResultSearch->code() == LDAP_SIZELIMIT_EXCEEDED ) {
 
-            # Result code 4 (LDAP_SIZELIMIT_EXCEEDED) is normal if there
-            # are more items in LDAP than search limit defined in OTRS or
+            # LDAP_SIZELIMIT_EXCEEDED result is ok if there
+            # are more items in LDAP than search limit defined in Znuny or
             # in LDAP server. Avoid spamming logs with such errors.
             $Kernel::OM->Get('Kernel::System::Log')->Log(
                 Priority => 'debug',
@@ -1219,10 +1221,10 @@ sub CustomerIDList {
     # log ldap errors
     if ( $Result->code() ) {
 
-        if ( $Result->code() == 4 ) {
+        if ( $Result->code() == LDAP_SIZELIMIT_EXCEEDED) {
 
-            # Result code 4 (LDAP_SIZELIMIT_EXCEEDED) is normal if there
-            # are more items in LDAP than search limit defined in OTRS or
+            # LDAP_SIZELIMIT_EXCEEDED result is ok if there
+            # are more items in LDAP than search limit defined in Znuny or
             # in LDAP server. Avoid spamming logs with such errors.
             $Kernel::OM->Get('Kernel::System::Log')->Log(
                 Priority => 'debug',

--- a/Kernel/System/CustomerUser/LDAP.pm
+++ b/Kernel/System/CustomerUser/LDAP.pm
@@ -10,11 +10,14 @@
 
 package Kernel::System::CustomerUser::LDAP;
 
+# Throws errors when using LDAP_SIZELIMIT_EXCEEDED constant so disabled for now.
+## nofilter(TidyAll::Plugin::OTRS::Perl::SyntaxCheck)
+
 use strict;
 use warnings;
 
 use Net::LDAP;
-use Net::LDAP qw(LDAP_SIZELIMIT_EXCEEDED);
+use Net::LDAP::Constant qw(LDAP_SIZELIMIT_EXCEEDED);
 use Net::LDAP::Util qw(escape_filter_value);
 
 use Kernel::System::VariableCheck qw(:all);

--- a/Kernel/System/CustomerUser/LDAP.pm
+++ b/Kernel/System/CustomerUser/LDAP.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021-2022 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you


### PR DESCRIPTION
## Proposed change
This mod changes LDAP search limit message priority from error to debug in CustomerSearchDetail() like in b574f54d2599956cb18af139fcf5f28d3ccb67fb to avoid unnecessary error log flooding.

## Type of change
- '1 - 🐞 bug 🐞'            - Bugfix (non-breaking change which fixes an issue)

## Additional information

Related: https://github.com/OTRS/otrs/pull/1308
Author-Change-Id: IB#1113507

## Checklist
- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [x] Local ZnunyCodePolicy run passes successfully.(❕)
- [x] Local unit tests pass.(❕)
- [ ] GitHub workflow ZnunyCodePolicy passes.(❗)
- [ ] GitHub workflow unit tests pass.(❗)
