### PR TITLE
List all configured calendars in support data collector

### DIFF
--- a/Kernel/System/SupportDataCollector/Plugin/OTRS/TimeSettings.pm
+++ b/Kernel/System/SupportDataCollector/Plugin/OTRS/TimeSettings.pm
@@ -78,7 +78,14 @@ sub Run {
     }
 
     # Calendar time zones
-    for my $Counter ( 1 .. 9 ) {
+    my $Maximum = $ConfigObject->Get("MaximumCalendarNumber") || 50; 
+
+    COUNTER:
+    for my $Counter ( '', 1 .. $Maximum ) {
+        my $CalendarName = $ConfigObject->Get('TimeZone::Calendar' . $Counter . 'Name' );
+
+        next COUNTER if !$CalendarName;
+
         my $CalendarTimeZone = $ConfigObject->Get( 'TimeZone::Calendar' . $Counter );
 
         if ( defined $CalendarTimeZone ) {


### PR DESCRIPTION
<!--
  You are amazing! 🚀
  Thanks for contributing to the Znuny community project!
  Please, DO NOT DELETE ANY TEXT from this template (unless instructed)!

### Licensing, copyright and credits

Znuny is an open fork of an existing software. So we have to respect the already given copyright of the original creators.

New files will be licensed using the AGPL Version 3. If you contribute code to the Znuny project you will get mentioned in the pull request incl. the commit, in CHANGES.md and in AUTHORS.md. We will not mention you in the file you provided or changed. Your work is highly appreciated and acknowledged but you contribute it to the project and your copyright will pass on to the fork itself.
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why this pull request should be accepted. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

One can define more than just the default 9 calendars. In AdminSLA and AdminQueue this is already implemented, but not in the support data collector. This PR fixes that.

The support data list the calendars their configured time zones. If there are more than 9 calendars in the system configuration, the support data just list the calendars 1..9. After applying this patch, all the configured calendars are listed.

The calendar name is checked to check if the calendar is configured. Otherwise the support data would list 50 calendars (or whatever is configured as the maximum number of calendars) no matter if the calendars exist in the system configuration or not.



<!--
## Type of change
  What type of change does your PR introduce to Znuny?
  NOTE: Please add only one label with a starting '1 - ' to this PR!
  If your PR requires multiple labels to be applied, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster for the code review.

- '1 - 🆙 dependency upgrade - Dependency upgrade (e.g. libraries)
- '1 - 🐞 bug 🐞'            - Bugfix (non-breaking change which fixes an issue)
- '1 - 💎 code quality'      - Code quality improvements to existing code or addition of unit tests
- '1 - 🚀 feature'           - New feature (which adds functionality to an existing integration)
- '1 - ...'

-->


- '1 - 🐞 bug 🐞'            - Bugfix (non-breaking change which fixes an issue)


## Checklist
<!--
  Put an 'x' in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  ❕ - nice to have
  ❗ - required before review
-->

- [X] The code change is tested and works locally.(❗)
- [X] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [ ] Local ZnunyCodePolicy run passes successfully.(❕)
- [ ] Local unit tests pass.(❕)
- [x] GitHub workflow ZnunyCodePolicy passes.(❗)
- [x] GitHub workflow unit tests pass.(❗)

<!--
  Thank you for contributing ❤

  Znuny @znuny/znuny
-->
