### PR TITLE
Bad Content-ID formatting handling in DetectAttachment filter fixed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# 6.0.40 2022-??-??
+ - 2022-01-20 Bad Content-ID formatting handling in DetectAttachment filter fixed.
+
 # 6.0.39 2021-12-15
  - 2021-12-14 Added ProcessListTreeView in AgentTicketProcess and CustomerTicketProcess.
  - 2021-12-14 Added missing translation for process and activity in CustomerTicketZoom.tt.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,3 @@
-# 6.0.40 2022-??-??
- - 2022-01-20 Bad Content-ID formatting handling in DetectAttachment filter fixed.
-
 # 6.0.39 2021-12-15
  - 2021-12-14 Added ProcessListTreeView in AgentTicketProcess and CustomerTicketProcess.
  - 2021-12-14 Added missing translation for process and activity in CustomerTicketZoom.tt.

--- a/Kernel/System/PostMaster/Filter/DetectAttachment.pm
+++ b/Kernel/System/PostMaster/Filter/DetectAttachment.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2022 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -61,8 +62,17 @@ sub Run {
             )
         {
             my ($ImageID) = ( $Attachment->{ContentID} =~ m{^<(.*)>$}ixms );
-            if ( grep { $_->{Content} =~ m{<img.*src=.*['|"]cid:\Q$ImageID\E['|"].*>}ixms } @Attachments ) {
-                $AttachmentInline = 1;
+
+            # Tolerate ContentID without surrounding <>.
+            if (! defined $ImageID) {
+                $ImageID = $Attachment->{ContentID};
+            }
+
+            # Inline image must not have empty ContentID (<>).
+            if (length $ImageID) {
+                if ( grep { $_->{Content} =~ m{<img.*src=.*['|"]cid:\Q$ImageID\E['|"].*>}ixms } @Attachments ) {
+                    $AttachmentInline = 1;
+                }
             }
         }
 

--- a/Kernel/System/PostMaster/Filter/DetectAttachment.pm
+++ b/Kernel/System/PostMaster/Filter/DetectAttachment.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2022 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/scripts/test/PostMaster/Attachments.t
+++ b/scripts/test/PostMaster/Attachments.t
@@ -132,6 +132,12 @@ my $EmailInlineImage = $MainObject->FileRead(
     Result   => 'ARRAY',
 );
 
+# Read email content that contains inline image with bad Content-ID formatting.
+my $EmailInlineImageBadContentIDFormatting = $MainObject->FileRead(
+    Location => $ConfigObject->Get('Home') . '/scripts/test/sample/PostMaster/InlineImage1.box',
+    Result   => 'ARRAY',
+);
+
 # Workaround due used email have not a From value
 unshift @{$EmailAttachment}, 'From: Sender <sender@example.com>';
 
@@ -228,6 +234,34 @@ my @Tests = (
             DynamicField_TicketFreeText2 => undef,
         },
         Email => $EmailInlineImage,
+    },
+    {
+        Name  => '#4 - With Inline Images and bad Content-ID formatting',
+        Match => [
+            {
+                Key   => 'X-OTRS-AttachmentExists',
+                Value => 'yes',
+            },
+            {
+                Key   => 'X-OTRS-AttachmentCount',
+                Value => 1,
+            }
+        ],
+        Set => [
+            {
+                Key   => 'X-OTRS-DynamicField-TicketFreeText1',
+                Value => 'This should not be set',
+            },
+            {
+                Key   => 'X-OTRS-DynamicField-TicketFreeText2',
+                Value => 'This should not be set',
+            },
+        ],
+        Check => {
+            DynamicField_TicketFreeText1 => undef,
+            DynamicField_TicketFreeText2 => undef,
+        },
+        Email => $EmailInlineImageBadContentIDFormatting,
     },
 );
 

--- a/scripts/test/sample/PostMaster/InlineImage1.box
+++ b/scripts/test/sample/PostMaster/InlineImage1.box
@@ -1,0 +1,50 @@
+From: test <test@test.com>
+Subject: test
+To: test1 <test1@test.com>
+Message-ID: <test104@test.com>
+Date: Fri, 28 Jul 2017 12:25:43 +0200
+MIME-Version: 1.0
+Content-Type: multipart/alternative;
+ boundary="------------09D1E0375BAA13EBAAD61733"
+Content-Language: pl
+
+This is a multi-part message in MIME format.
+--------------09D1E0375BAA13EBAAD61733
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+test img:
+
+
+--------------09D1E0375BAA13EBAAD61733
+Content-Type: multipart/related;
+ boundary="------------040237935DECF5A5EBB29292"
+
+
+--------------040237935DECF5A5EBB29292
+Content-Type: text/html; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+<html>
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+  </head>
+  <body text="#000000" bgcolor="#FFFFFF">
+    <p><font size="-1"><font face="Verdana">test img: <img
+            src="cid:image1@test.com" alt="" class=""></font></font></p>
+  </body>
+</html>
+
+--------------040237935DECF5A5EBB29292
+Content-Type: image/png;
+ name="test.png"
+Content-Transfer-Encoding: base64
+Content-ID: image1@test.com
+Content-Disposition: attachment;
+ filename="test.png"
+
+iVBORw0KGgoAAAANSUhEUgAAAB4AAAAeAQMAAAAB/jzhAAAAA1BMVEVV5ytwjk3qAAAADElE
+QVQI12NgGIwAAACWAAFiFg3SAAAAAElFTkSuQmCC
+--------------040237935DECF5A5EBB29292--
+
+--------------09D1E0375BAA13EBAAD61733--


### PR DESCRIPTION
## Proposed change

Znuny throws

`Use of uninitialized value $ImageID in quotemeta at [...]DetectAttachment.pm line 65`

error when importing e-mail message with inline image with Content-ID header value
without <>. Such formatting is not allowed by RFC

https://datatracker.ietf.org/doc/html/rfc2392#section-2

but is accepted Znuny in

https://github.com/znuny/Znuny/blob/rel-6_0/Kernel/System/Ticket/Article/Backend/MIMEBase/ArticleStorageFS.pm#L372

so it should tolerate it also in DetectAttachment.pm.

This mod fixes it.

## Type of change
- '1 - 🐞 bug 🐞'            - Bugfix (non-breaking change which fixes an issue)


## Additional information
Related: https://datatracker.ietf.org/doc/html/rfc2392#section-2
Author-Change-Id: IB#1114877

## Checklist
<!--
  Put an 'x' in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  ❕ - nice to have
  ❗ - required before review
-->

- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [x] You improved or added new unit tests.(❕)
- [x] Local ZnunyCodePolicy run passes successfully.(❕)
- [x] Local unit tests pass.(❕)
- [ ] GitHub workflow ZnunyCodePolicy passes.(❗)
- [ ] GitHub workflow unit tests pass.(❗)
