### PR TITLE
Sector Nord AG: Workaround for JQuery bug in DOM tree

### DIFF
--- a/Kernel/Output/JavaScript/Templates/Standard/Agent/AppointmentCalendar/AppointmentTooltip.html.tmpl
+++ b/Kernel/Output/JavaScript/Templates/Standard/Agent/AppointmentCalendar/AppointmentTooltip.html.tmpl
@@ -10,19 +10,19 @@
 <div class="AppointmentTooltip Hidden">
     <div class="Icons">
     {% if CalEvent.allDay %}
-        <i class="fa fa-sun-o" />
+        <i class="fa fa-sun-o"></i>
     {% endif %}
     {% if CalEvent.recurring %}
-        <i class="fa fa-repeat" />
+        <i class="fa fa-repeat"></i>
     {% endif %}
     {% if CalEvent.parentId %}
-        <i class="fa fa-link" />
+        <i class="fa fa-link"></i>
     {% endif %}
     {% if CalEvent.notification %}
-        <i class="fa fa-bell" />
+        <i class="fa fa-bell"></i>
     {% endif %}
     {% if CalEvent.ticketAppointmentType %}
-        <i class="fa fa-char-{{ TicketAppointmentConfig[CalEvent.ticketAppointmentType].Mark }}" />
+        <i class="fa fa-char-{{ TicketAppointmentConfig[CalEvent.ticketAppointmentType].Mark }}"></i>
     {% endif %}
     </div>
     <fieldset>


### PR DESCRIPTION
<!--
  You are amazing! 🚀
  Thanks for contributing to the Znuny community project!
  Please, DO NOT DELETE ANY TEXT from this template (unless instructed)!

### Licensing, copyright and credits

Znuny is an open fork of an existing software. So we have to respect the already given copyright of the original creators.

New files will be licensed using the AGPL Version 3. If you contribute code to the Znuny project you will get mentioned in the pull request incl. the commit, in CHANGES.md and in AUTHORS.md. We will not mention you in the file you provided or changed. Your work is highly appreciated and acknowledged but you contribute it to the project and your copyright will pass on to the fork itself.
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why this pull request should be accepted. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

If an appointment is set to recurring or all day, the preview of the appointment does not look correct. The font and the table is wrong.
The preview can be viewed when hovering over the appointment in AgentAppointmentCalendarOverview.

All day appointment:
![image](https://user-images.githubusercontent.com/91074418/155703084-24d51f5d-f64e-482d-ae93-f47558974658.png)

Normal appointment:
![image](https://user-images.githubusercontent.com/91074418/155703515-b8d89784-fb7e-4dda-86af-9dafd664b552.png)


<!--
## Type of change
  What type of change does your PR introduce to Znuny?
  NOTE: Please add only one label with a starting '1 - ' to this PR!
  If your PR requires multiple labels to be applied, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster for the code review.

- '1 - 🆙 dependency upgrade - Dependency upgrade (e.g. libraries)
- '1 - 🐞 bug 🐞'            - Bugfix (non-breaking change which fixes an issue)
- '1 - 💎 code quality'      - Code quality improvements to existing code or addition of unit tests
- '1 - 🚀 feature'           - New feature (which adds functionality to an existing integration)
- '1 - ...'

-->
## Type of change
- '1 - 🐞 bug 🐞' 

## Additional information
* The problem appears at least in Version 6.2.2 and 6.0.30.
* The problem does not appear in Version 6.0.22.
* The problem appears in Chrome, Firefox and Edge.

I analyzed the problem a little bit deeper and I found an issue with JQuery.
* The problem appears in JQuery 3.6.0 and not in JQuery 3.2.1.

In `Core.Agent.AppointmentCalendar.js` line 380 the correct HTML string will be converted to a wrong DOM tree:
```
// Create tooltip object
$TooltipObj = $(TooltipHTML)
    .offset({
        top: PosY,
        left: PosX
    })
    .appendTo('body');
```

Correct HTML String:
```
<div class="AppointmentTooltip Hidden">
    <div class="Icons">
        <i class="fa fa-sun-o" />
    </div>
    <fieldset>
        <legend><span>Grundlegende Informationen</span></legend>
...
```

And after the wrong conversion:
```
<div class="AppointmentTooltip Hidden" style="top: 326px; left: 1212px;">
    <div class="Icons">
        <i class="fa fa-sun-o">
    </i></div><i class="fa fa-sun-o">
    <fieldset>
        <legend><span>Grundlegende Informationen</span></legend>
...
```
The fieldset should not be a part of the `<i>`

To see the bug in a minimal environment, just open the browser console and try the following commands:
JQuery version should be `console.log(jQuery().jquery);` equal to `3.6.0`

```
$('<div><div><i/></div>Something</div>')[0].outerHTML;

'<div><div><i></i></div><i>Something</i></div>'
```
There should not be a `<i>` around `Something`.

A workaround is to use `<i></i>`instead of `<i/>`: - like in this pull request.
```
$('<div><div><i></i></div>Something</div>')[0].outerHTML;

'<div><div><i></i></div>Something</div>'
```

<!--
- This PR is related to PR: #
- ...
-->

## Checklist
<!--
  Put an 'x' in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  ❕ - nice to have
  ❗ - required before review
-->

- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [ ] Local ZnunyCodePolicy run passes successfully.(❕)
- [ ] Local unit tests pass.(❕)
- [ ] GitHub workflow ZnunyCodePolicy passes.(❗)
- [ ] GitHub workflow unit tests pass.(❗)

<!--
  Thank you for contributing ❤

  Znuny @znuny/znuny
-->
