### PR TITLE
Sector Nord AG: Fixed transition action for recurring appointments with specific recurrence frequency

### DIFF
--- a/Kernel/System/ProcessManagement/TransitionAction/AppointmentCreate.pm
+++ b/Kernel/System/ProcessManagement/TransitionAction/AppointmentCreate.pm
@@ -162,7 +162,7 @@ sub Run {
     for my $Param (qw(TeamID ResourceID RecurrenceFrequency RecurrenceExclude )) {
         next PARAM if !defined $Param{Config}->{$Param};
 
-        $Param{Config}->{$Param} = split /\s*,\s*/, $Param{Config}->{$Param};
+        $Param{Config}->{$Param} = [ split /\s*,\s*/, $Param{Config}->{$Param} ];
     }
 
     # be sure that the date parameters are always in the correct format

--- a/Kernel/System/ProcessManagement/TransitionAction/AppointmentUpdate.pm
+++ b/Kernel/System/ProcessManagement/TransitionAction/AppointmentUpdate.pm
@@ -160,7 +160,7 @@ sub Run {
     for my $Param (qw(TeamID ResourceID RecurrenceFrequency RecurrenceExclude )) {
         next PARAM if !defined $Param{Config}->{$Param};
 
-        $Param{Config}->{$Param} = split /\s*,\s*/, $Param{Config}->{$Param};
+        $Param{Config}->{$Param} = [ split /\s*,\s*/, $Param{Config}->{$Param} ];
     }
 
     # be sure that the date parameters are always in the correct format

--- a/scripts/test/ProcessManagement/TransitionAction/AppointmentUpdate.t
+++ b/scripts/test/ProcessManagement/TransitionAction/AppointmentUpdate.t
@@ -95,35 +95,98 @@ $Self->True(
     'DynamicField_AppointmentID got filled correctly',
 );
 
-my $TransitionActionResult = $TransitionActionObject->Run(
-    UserID                   => 1,
-    Ticket                   => \%Ticket,
-    ProcessEntityID          => 'P123',
-    ActivityEntityID         => 'A123',
-    TransitionEntityID       => 'T123',
-    TransitionActionEntityID => 'TA123',
-    Config                   => {
-        CalendarName  => $CalendarName,
-        Title         => 'New Webinar',
-        StartTime     => '2022-01-01',
-        EndTime       => '2022-01-02',
-        AppointmentID => '<OTRS_TICKET_DynamicField_AppointmentID>',
-        UserID        => 1,
+my $AppointmentTitle1 = 'Appointment ' . $HelperObject->GetRandomNumber();
+my $AppointmentTitle2 = 'Appointment ' . $HelperObject->GetRandomNumber();
+my @Tests = (
+    {
+        Name  => 'Create appointment',
+        Config  => {
+            CalendarName               => $CalendarName,
+            AppointmentID              => '<OTRS_TICKET_DynamicField_AppointmentID>',
+            Title                      => $AppointmentTitle1,
+            StartTime                  => '2022-01-01',
+            EndTime                    => '2022-01-02',
+            DynamicField_AppointmentID => 'AppointmentID',
+            UserID                     => 1
+        },
+        Result => {
+            Title                      => $AppointmentTitle1,
+            StartTime                  => '2022-01-01 00:00:00',
+            EndTime                    => '2022-01-02 00:00:00',
+        },
+    },
+    {
+        Name  => 'Create recurring appointment',
+        Config  => {
+            CalendarName               => $CalendarName,
+            AppointmentID              => '<OTRS_TICKET_DynamicField_AppointmentID>',
+            Title                      => $AppointmentTitle2,
+            StartTime                  => '2022-02-01 10:00:00',
+            EndTime                    => '2022-02-02 11:00:00',
+            DynamicField_AppointmentID => 'AppointmentID',
+            UserID                     => 1,
+            Recurring                  => '1',
+            RecurrenceType             => 'CustomWeekly',
+            RecurrenceFrequency        => '2, 3',
+            RecurrenceInterval         => 2,
+            RecurrenceUntil            => '',
+        },
+        Result => {
+            Title               => $AppointmentTitle2,
+            StartTime           => '2022-02-01 10:00:00',
+            EndTime             => '2022-02-02 11:00:00',
+            RecurrenceFrequency => [
+                2, 3
+            ],
+            RecurrenceInterval  => '2',
+            RecurrenceType      => 'CustomWeekly',
+            Recurring           => '1'
+        },
     },
 );
-$Self->True(
-    $TransitionActionResult,
-    'TransitionActionObject->Run()',
-);
 
-my %Appointment = $AppointmentObject->AppointmentGet(
-    AppointmentID => $Ticket{DynamicField_AppointmentID},
-    CalendarID    => $Calendar{CalendarID},
-);
-$Self->Is(
-    $Appointment{Title},
-    'New Webinar',
-    'Appointment got updated successfully',
-);
+for my $Test (@Tests) {
+    # run function
+    my $TransitionActionResult = $TransitionActionObject->Run(
+        UserID                   => 1,
+        Ticket                   => \%Ticket,
+        ProcessEntityID          => 'P123',
+        ActivityEntityID         => 'A123',
+        TransitionEntityID       => 'T123',
+        TransitionActionEntityID => 'TA123',
+        Config                   => {
+            %{ $Test->{Config} }
+        },
+    );
+
+    $Self->True(
+        $TransitionActionResult,
+        'TransitionActionObject->Run()',
+    );
+
+    %Ticket = $TicketObject->TicketGet(
+        TicketID      => $TicketID,
+        DynamicFields => 1,
+        UserID        => 1,
+    );
+
+    $Self->True(
+        $Ticket{DynamicField_AppointmentID},
+        'DynamicField_AppointmentID got filled correctly',
+    );
+
+    my %Appointment = $AppointmentObject->AppointmentGet(
+        AppointmentID => $Ticket{DynamicField_AppointmentID},
+        CalendarID    => $Calendar{CalendarID},
+    );
+
+    for my $Field ( keys %{ $Test->{Result} } ) {
+        $Self->IsDeeply(
+            $Appointment{$Field},
+            $Test->{Result}->{$Field},
+            $Test->{Name} . ' - appointment field ' . $Field . ' is correct',
+        );
+    }
+}
 
 1;


### PR DESCRIPTION
<!--
  You are amazing! 🚀
  Thanks for contributing to the Znuny community project!
  Please, DO NOT DELETE ANY TEXT from this template (unless instructed)!

### Licensing, copyright and credits

Znuny is an open fork of an existing software. So we have to respect the already given copyright of the original creators.

New files will be licensed using the AGPL Version 3. If you contribute code to the Znuny project you will get mentioned in the pull request incl. the commit, in CHANGES.md and in AUTHORS.md. We will not mention you in the file you provided or changed. Your work is highly appreciated and acknowledged but you contribute it to the project and your copyright will pass on to the fork itself.
-->

## Proposed change

When creating an appointment over the transition action `AppointmentCreate` with a specific recurrence frequency, no appointment will be created.

Data that I delivered to the transition action `AppointmentCreate`:
```
{
      'CalendarID' => '1',
      'RecurrenceFrequency' => '2, 3',
      'RecurrenceType' => 'CustomWeekly',
      'RecurrenceID' => '2022-03-02 14:32:00',
      'CalendarName' => 'Changemanagement',
      'Title' => 'Test 2022-03-02 14:32',
      'RecurrenceInterval' => '2',
      'RecurrenceUntil' => '',
      'EndTime' => '2022-03-02 15:32:00',
      'StartTime' => '2022-03-02 14:32:00',
      'Description' => 'Test',
      'Recurring' => '1',
      'DynamicField_AppointmentID' => 'ChangeAppointmentID'
}
```

Error Message:
`Runtime error: Can't use string ("2") as an ARRAY ref while "strict refs" in use at /opt/otrs/Kernel/System/Calendar/Appointment.pm line 260`

I located the problem in the following line in `Kernel/System/ProcessManagement/TransitionAction/AppointmentCreate.pm`:
```
$Param{Config}->{$Param} = split /\s*,\s*/, $Param{Config}->{$Param};
```
The string `2, 3` should be converted in an array `[ 2, 3 ]`. But it will be converted to the scalar of the array `2`.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why this pull request should be accepted. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

<!--
## Type of change
  What type of change does your PR introduce to Znuny?
  NOTE: Please add only one label with a starting '1 - ' to this PR!
  If your PR requires multiple labels to be applied, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster for the code review.

- '1 - 🆙 dependency upgrade - Dependency upgrade (e.g. libraries)
- '1 - 🐞 bug 🐞'            - Bugfix (non-breaking change which fixes an issue)
- '1 - 💎 code quality'      - Code quality improvements to existing code or addition of unit tests
- '1 - 🚀 feature'           - New feature (which adds functionality to an existing integration)
- '1 - ...'

-->
## Type of change
- '1 - 🐞 bug 🐞'   

## Additional information
<!--
  Details are important and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  Note: Remove this section if not needed.

  If a PR is related to an issue, please use the 'Linked issues' function on the sidebar.
-->
The same problem can be reproduced with `AppointmentUpdate`.

I found the bug and tested the solution in Znuny 6.2.1.

I added some unittests to check this problem.

<!--
- This PR is related to PR: #
- ...
-->

## Checklist
<!--
  Put an 'x' in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  ❕ - nice to have
  ❗ - required before review
-->

- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [x] You improved or added new unit tests.(❕)
- [x] Local ZnunyCodePolicy run passes successfully.(❕)
- [x] Local unit tests pass.(❕)
- [ ] GitHub workflow ZnunyCodePolicy passes.(❗)
- [ ] GitHub workflow unit tests pass.(❗)

<!--
  Thank you for contributing ❤

  Znuny @znuny/znuny
-->
