### PR TITLE
Add support for CustomerIDRaw in GenericInterface TicketSearch operation

### DIFF
--- a/Kernel/GenericInterface/Operation/Ticket/TicketSearch.pm
+++ b/Kernel/GenericInterface/Operation/Ticket/TicketSearch.pm
@@ -115,6 +115,13 @@ perform TicketSearch Operation. This will return a Ticket ID list.
         CustomerID => '123',
         CustomerID => ['123', 'ABC'],
 
+        # CustomerIDRaw (optional) as STRING or as ARRAYREF
+        # CustomerID without QueryCondition checking.
+        # The param CustomerID will be ignored when CustomerIDRaw is set.
+        # The raw values will be quoted and combined with 'OR' for the query.
+        CustomerIDRaw => '123 + 345',
+        CustomerIDRaw => ['123', 'ABC','123 && 456','ABC % efg'],
+
         # CustomerUserLogin (optional) as STRING as ARRAYREF
         CustomerUserLogin => 'uid123',
         CustomerUserLogin => ['uid123', 'uid777'],
@@ -402,7 +409,7 @@ sub _GetParams {
         CreatedTypes CreatedTypeIDs CreatedPriorities
         CreatedPriorityIDs CreatedStates CreatedStateIDs
         CreatedQueues CreatedQueueIDs StateType CustomerID
-        CustomerUserLogin )
+        CustomerIDRaw CustomerUserLogin )
         )
     {
 


### PR DESCRIPTION
<!--
  You are amazing! 🚀
  Thanks for contributing to the Znuny community project!
  Please, DO NOT DELETE ANY TEXT from this template (unless instructed)!

### Licensing, copyright and credits

Znuny is an open fork of an existing software. So we have to respect the already given copyright of the original creators.

New files will be licensed using the AGPL Version 3. If you contribute code to the Znuny project you will get mentioned in the pull request incl. the commit, in CHANGES.md and in AUTHORS.md. We will not mention you in the file you provided or changed. Your work is highly appreciated and acknowledged but you contribute it to the project and your copyright will pass on to the fork itself.
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why this pull request should be accepted. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Given a ticket with the customer id dummy+mojo@perl-services.de, you can't find
this ticket via the GenericInterface TicketSearch operation. This is the same
issue the standard TicketSearch functionality affected some time ago and that's
the reason the TicketSearch module added CustomerIDRaw at that time.

Unfortunately, the TicketSearch operation wasn't changed back then.

This is the ticket information from a sample ticket:

![image](https://user-images.githubusercontent.com/144096/162994891-5f142de0-93f2-4ef3-9ce9-27f18359fbef.png)

And this is a sample request with only CustomerID:

![image](https://user-images.githubusercontent.com/144096/162995027-35e36afe-a490-4dd9-a935-969ccd097ffb.png)

And the same request with CustomerIDRaw instead of CustomerID:

![image](https://user-images.githubusercontent.com/144096/162995174-a2b58b99-af86-4820-9d1d-7850daba104a.png)


<!--
## Type of change
  What type of change does your PR introduce to Znuny?
  NOTE: Please add only one label with a starting '1 - ' to this PR!
  If your PR requires multiple labels to be applied, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster for the code review.

- '1 - 🆙 dependency upgrade - Dependency upgrade (e.g. libraries)
- '1 - 🐞 bug 🐞'            - Bugfix (non-breaking change which fixes an issue)
- '1 - 💎 code quality'      - Code quality improvements to existing code or addition of unit tests
- '1 - 🚀 feature'           - New feature (which adds functionality to an existing integration)
- '1 - ...'

-->

- '1 - 🐞 bug 🐞'            - Bugfix (non-breaking change which fixes an issue)

## Breaking change
<!--
  If your PR contains a breaking change, it is important
  to tell what breaks, how to make it work again and why it is necessary.
  This piece of text is published with the release notes, so it helps if you
  write it for the users, not the maintainer.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Additional information
<!--
  Details are important and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  Note: Remove this section if not needed.

  If a PR is related to an issue, please use the 'Linked issues' function on the sidebar.
-->

<!--
- This PR is related to PR: #
- ...
-->

## Checklist
<!--
  Put an 'x' in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  ❕ - nice to have
  ❗ - required before review
-->

- [X] The code change is tested and works locally.(❗)
- [X] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [ ] Local ZnunyCodePolicy run passes successfully.(❕)
- [ ] Local unit tests pass.(❕)
- [ ] GitHub workflow ZnunyCodePolicy passes.(❗)
- [ ] GitHub workflow unit tests pass.(❗)

<!--
  Thank you for contributing ❤

  Znuny @znuny/znuny
-->
