### PR TITLE
Changed agent-entry in the ticket-history for mention-notifications to responsible agent

### DIFF
--- a/Kernel/System/Ticket/Event/Mentions.pm
+++ b/Kernel/System/Ticket/Event/Mentions.pm
@@ -72,6 +72,7 @@ sub Run {
         Recipients => \%Recipients,
         TicketID   => $Param{Data}{TicketID},
         ArticleID  => $Param{Data}{ArticleID},
+        UserID     => $Param{UserID},
     );
 
     return \%Recipients;

--- a/scripts/test/Mentions/Mentions.t
+++ b/scripts/test/Mentions/Mentions.t
@@ -95,7 +95,8 @@ for my $ArticleID (@ArticleIDs) {
             UserID => $UserID
         },
         TicketID  => $TicketID,
-        ArticleID => $ArticleID
+        ArticleID => $ArticleID,
+        UserID    => 1,
     );
     $Self->True(
         $Success,
@@ -128,7 +129,8 @@ my $Success = $MentionObject->AddMention(
         UserID => $UserID
     },
     TicketID  => $TicketID,
-    ArticleID => $ArticleIDs[0]
+    ArticleID => $ArticleIDs[0],
+    UserID    => 1,
 );
 
 $Self->True(

--- a/scripts/test/Mentions/MentionsPermissionCheck.t
+++ b/scripts/test/Mentions/MentionsPermissionCheck.t
@@ -96,7 +96,8 @@ my $Success = $MentionObject->AddMention(
         UserID => $UserID
     },
     TicketID  => $TicketID,
-    ArticleID => $ArticleID
+    ArticleID => $ArticleID,
+    UserID    => 1,
 );
 
 @Ticket = $TicketObject->TicketSearch(


### PR DESCRIPTION
<!--
  You are amazing! 🚀
  Thanks for contributing to the Znuny community project!
  Please, DO NOT DELETE ANY TEXT from this template (unless instructed)!

### Licensing, copyright and credits

Znuny is an open fork of an existing software. So we have to respect the already given copyright of the original creators.

New files will be licensed using the AGPL Version 3. If you contribute code to the Znuny project you will get mentioned in the pull request incl. the commit, in CHANGES.md and in AUTHORS.md. We will not mention you in the file you provided or changed. Your work is highly appreciated and acknowledged but you contribute it to the project and your copyright will pass on to the fork itself.
-->

## Proposed change
Currently, when a user is mentioned and a notification to that user is triggered, AgentTicketHistory shows this user (the recipient of that notification) on the left site.
![wrong](https://user-images.githubusercontent.com/80031303/182230732-3593b193-3977-46b0-be02-5bff20312a6b.png)
Usually the left position indicates that this user triggered an action. This PR fixes this and writes the user who triggert the action into that field.
![right](https://user-images.githubusercontent.com/80031303/182230919-f8269420-47c6-4131-94a9-1b5b16ede4cc.png)

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why this pull request should be accepted. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change
1 - 🐞 bug 🐞
<!--
  What type of change does your PR introduce to Znuny?
  NOTE: Please add only one label with a starting '1 - ' to this PR!
  If your PR requires multiple labels to be applied, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster for the code review.

- '1 - 🆙 dependency upgrade - Dependency upgrade (e.g. libraries)
- '1 - 🐞 bug 🐞'            - Bugfix (non-breaking change which fixes an issue)
- '1 - 💎 code quality'      - Code quality improvements to existing code or addition of unit tests
- '1 - 🚀 feature'           - New feature (which adds functionality to an existing integration)
- '1 - ...'

-->

## Breaking change
<!--
  If your PR contains a breaking change, it is important
  to tell what breaks, how to make it work again and why it is necessary.
  This piece of text is published with the release notes, so it helps if you
  write it for the users, not the maintainer.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Additional information
<!--
  Details are important and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  Note: Remove this section if not needed.

  If a PR is related to an issue, please use the 'Linked issues' function on the sidebar.
-->

<!--
- This PR is related to PR: #
- ...
-->

## Checklist
<!--
  Put an 'x' in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  ❕ - nice to have
  ❗ - required before review
-->

- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [x] You improved or added new unit tests.(❕)
- [x] Local ZnunyCodePolicy run passes successfully.(❕)
- [x] Local unit tests pass.(❕)
- [x] GitHub workflow ZnunyCodePolicy passes.(❗)
- [x] GitHub workflow unit tests pass.(❗)

<!--
  Thank you for contributing ❤

  Znuny @znuny/znuny
-->
