### PR TITLE
Standard Process Templates-Feature gets triggered too often

### DIFF
--- a/Kernel/Modules/AgentTicketProcess.pm
+++ b/Kernel/Modules/AgentTicketProcess.pm
@@ -806,7 +806,7 @@ sub _RenderAjax {
             );
             $FieldsProcessed{ $Self->{NameToID}{$CurrentField} } = 1;
         }
-        elsif ( $Self->{NameToID}{$CurrentField} eq 'Article' ) {
+        elsif ( $Self->{NameToID}{$CurrentField} eq 'Article' && $Param{GetParam}{ElementChanged} eq 'StandardTemplateID' ) {
             next DIALOGFIELD if $FieldsProcessed{ $Self->{NameToID}{$CurrentField} };
 
             my $TemplateGeneratorObject = $Kernel::OM->Get('Kernel::System::TemplateGenerator');
@@ -814,47 +814,51 @@ sub _RenderAjax {
             my $StdAttachmentObject     = $Kernel::OM->Get('Kernel::System::StdAttachment');
             my $UploadCacheObject       = $Kernel::OM->Get('Kernel::System::Web::UploadCache');
 
-            my %StandardTemplate = $StandardTemplateObject->StandardTemplateGet(
-                ID => $Param{GetParam}->{StandardTemplateID},
-            );
-
             # remove pre-submitted attachments
             $UploadCacheObject->FormIDRemove( FormID => $Self->{FormID} );
 
-            my $StandardTemplateText = $TemplateGeneratorObject->_Replace(
-                RichText => $LayoutObject->{BrowserRichText},
-                Text     => $StandardTemplate{Template},
-                Data     => {
-                    %{ $Param{GetParam} },
-                },
-                TicketData => {
-                    %{ $Param{GetParam} },
-                },
-                UserID => $Self->{UserID},
-            );
-
-            # add standard attachments to ticket
+            my $StandardTemplateText = '';
             my @TicketAttachments;
-            my %AllStdAttachments = $StdAttachmentObject->StdAttachmentStandardTemplateMemberList(
-                StandardTemplateID => $Param{GetParam}->{StandardTemplateID},
-            );
-            for my $ID ( sort keys %AllStdAttachments ) {
-                my %AttachmentsData = $StdAttachmentObject->StdAttachmentGet( ID => $ID );
-                $UploadCacheObject->FormIDAddFile(
-                    FormID      => $Self->{FormID},
-                    Disposition => 'attachment',
-                    %AttachmentsData,
-                );
-            }
 
-            @TicketAttachments = $UploadCacheObject->FormIDGetAllFilesMeta(
-                FormID => $Self->{FormID},
-            );
-
-            for my $Attachment (@TicketAttachments) {
-                $Attachment->{Filesize} = $LayoutObject->HumanReadableDataSize(
-                    Size => $Attachment->{Filesize},
+            if ( IsStringWithData( $Param{GetParam}->{StandardTemplateID} ) ) {
+                my %StandardTemplate = $StandardTemplateObject->StandardTemplateGet(
+                    ID => $Param{GetParam}->{StandardTemplateID},
                 );
+
+                $StandardTemplateText = $TemplateGeneratorObject->_Replace(
+                    RichText => $LayoutObject->{BrowserRichText},
+                    Text     => $StandardTemplate{Template},
+                    Data     => {
+                        %{ $Param{GetParam} },
+                    },
+                    TicketData => {
+                        %{ $Param{GetParam} },
+                    },
+                    UserID => $Self->{UserID},
+                );
+
+                # add standard attachments to ticket
+                my %AllStdAttachments = $StdAttachmentObject->StdAttachmentStandardTemplateMemberList(
+                    StandardTemplateID => $Param{GetParam}->{StandardTemplateID},
+                );
+                for my $ID ( sort keys %AllStdAttachments ) {
+                    my %AttachmentsData = $StdAttachmentObject->StdAttachmentGet( ID => $ID );
+                    $UploadCacheObject->FormIDAddFile(
+                        FormID      => $Self->{FormID},
+                        Disposition => 'attachment',
+                        %AttachmentsData,
+                    );
+                }
+
+                @TicketAttachments = $UploadCacheObject->FormIDGetAllFilesMeta(
+                    FormID => $Self->{FormID},
+                );
+
+                for my $Attachment (@TicketAttachments) {
+                    $Attachment->{Filesize} = $LayoutObject->HumanReadableDataSize(
+                        Size => $Attachment->{Filesize},
+                    );
+                }
             }
 
             push(

--- a/Kernel/Modules/CustomerTicketProcess.pm
+++ b/Kernel/Modules/CustomerTicketProcess.pm
@@ -673,7 +673,7 @@ sub _RenderAjax {
             );
             $FieldsProcessed{ $Self->{NameToID}{$CurrentField} } = 1;
         }
-        elsif ( $Self->{NameToID}{$CurrentField} eq 'Article' ) {
+        elsif ( $Self->{NameToID}{$CurrentField} eq 'Article' && $Param{GetParam}{ElementChanged} eq 'StandardTemplateID' ) {
             next DIALOGFIELD if $FieldsProcessed{ $Self->{NameToID}{$CurrentField} };
 
             my $TemplateGeneratorObject = $Kernel::OM->Get('Kernel::System::TemplateGenerator');
@@ -681,54 +681,58 @@ sub _RenderAjax {
             my $StdAttachmentObject     = $Kernel::OM->Get('Kernel::System::StdAttachment');
             my $UploadCacheObject       = $Kernel::OM->Get('Kernel::System::Web::UploadCache');
 
-            my %StandardTemplate = $StandardTemplateObject->StandardTemplateGet(
-                ID => $Param{GetParam}->{StandardTemplateID},
-            );
-
             # remove pre-submitted attachments
             $UploadCacheObject->FormIDRemove( FormID => $Self->{FormID} );
 
-            my $StandardTemplateText = $TemplateGeneratorObject->_Replace(
-                RichText => $LayoutObject->{BrowserRichText},
-                Text     => $StandardTemplate{Template},
-                Data     => {
-                    %{ $Param{GetParam} },
-                },
-                TicketData => {
-                    %{ $Param{GetParam} },
-                },
-                UserID => $Self->{UserID},
-            );
-
-            # add standard attachments to ticket
+            my $StandardTemplateText = '';
             my @TicketAttachments;
-            my %AllStdAttachments = $StdAttachmentObject->StdAttachmentStandardTemplateMemberList(
-                StandardTemplateID => $Param{GetParam}->{StandardTemplateID},
-            );
-            for my $ID ( sort keys %AllStdAttachments ) {
-                my %AttachmentsData = $StdAttachmentObject->StdAttachmentGet( ID => $ID );
-                $UploadCacheObject->FormIDAddFile(
-                    FormID      => $Self->{FormID},
-                    Disposition => 'attachment',
-                    %AttachmentsData,
-                );
-            }
 
-            @TicketAttachments = $UploadCacheObject->FormIDGetAllFilesMeta(
-                FormID => $Self->{FormID},
-            );
-
-            for my $Attachment (@TicketAttachments) {
-                $Attachment->{Filesize} = $LayoutObject->HumanReadableDataSize(
-                    Size => $Attachment->{Filesize},
+            if ( IsStringWithData( $Param{GetParam}->{StandardTemplateID} ) ) {
+                my %StandardTemplate = $StandardTemplateObject->StandardTemplateGet(
+                    ID => $Param{GetParam}->{StandardTemplateID},
                 );
+
+                $StandardTemplateText = $TemplateGeneratorObject->_Replace(
+                    RichText => $LayoutObject->{BrowserRichText},
+                    Text     => $StandardTemplate{Template},
+                    Data     => {
+                        %{ $Param{GetParam} },
+                    },
+                    TicketData => {
+                        %{ $Param{GetParam} },
+                    },
+                    UserID => $Self->{UserID},
+                );
+
+                # add standard attachments to ticket
+                my %AllStdAttachments = $StdAttachmentObject->StdAttachmentStandardTemplateMemberList(
+                    StandardTemplateID => $Param{GetParam}->{StandardTemplateID},
+                );
+                for my $ID ( sort keys %AllStdAttachments ) {
+                    my %AttachmentsData = $StdAttachmentObject->StdAttachmentGet( ID => $ID );
+                    $UploadCacheObject->FormIDAddFile(
+                        FormID      => $Self->{FormID},
+                        Disposition => 'attachment',
+                        %AttachmentsData,
+                    );
+                }
+
+                @TicketAttachments = $UploadCacheObject->FormIDGetAllFilesMeta(
+                    FormID => $Self->{FormID},
+                );
+
+                for my $Attachment (@TicketAttachments) {
+                    $Attachment->{Filesize} = $LayoutObject->HumanReadableDataSize(
+                        Size => $Attachment->{Filesize},
+                    );
+                }
             }
 
             push(
                 @JSONCollector,
                 {
                     Name => 'RichText',
-                    Data => $StandardTemplateText || '',
+                    Data => $StandardTemplateText // '',
                 },
                 {
                     Name     => 'TicketAttachments',
@@ -1119,6 +1123,7 @@ sub _GetParam {
     # and finally we'll have the special parameters:
     $GetParam{ResponsibleAll} = $ParamObject->GetParam( Param => 'ResponsibleAll' );
     $GetParam{OwnerAll}       = $ParamObject->GetParam( Param => 'OwnerAll' );
+    $GetParam{ElementChanged} = $ParamObject->GetParam( Param => 'ElementChanged' );
 
     return \%GetParam;
 }


### PR DESCRIPTION
<!--
  You are amazing! 🚀
  Thanks for contributing to the Znuny community project!
  Please, DO NOT DELETE ANY TEXT from this template (unless instructed)!

### Licensing, copyright and credits

Znuny is an open fork of an existing software. So we have to respect the already given copyright of the original creators.

New files will be licensed using the AGPL Version 3. If you contribute code to the Znuny project you will get mentioned in the pull request incl. the commit, in CHANGES.md and in AUTHORS.md. We will not mention you in the file you provided or changed. Your work is highly appreciated and acknowledged but you contribute it to the project and your copyright will pass on to the fork itself.
-->

## Proposed change
Currently, every AjaxUpdate in AgentTicketProcess expects to get a StandardTemplateID and returns a new article body.

This means every change, that creates an AjaxUpdate will overwrite the article body. Manual changes will get overwritten without warning.

If no template is selected, there will be additional errors in the log file and the body will be overwritten with an empty body.
<details>
  <summary>Error log (click to expand)</summary>
ERROR: OTRS-CGI-54 Perl: 5.30.0 OS: linux Time: Tue Aug 9 13:21:12 2022

 Message: Need ID!

 RemoteAddress: 10.0.2.2
 RequestURI: /Znuny-Dev/index.pl?

 Traceback (14614):
   Module: Kernel::System::StandardTemplate::StandardTemplateGet Line: 152
   Module: Kernel::Modules::AgentTicketProcess::_RenderAjax Line: 821
   Module: Kernel::Modules::AgentTicketProcess::Run Line: 458
   Module: Kernel::System::Web::InterfaceAgent::Run Line: 1144
   Module: /opt/frameworks/Znuny-Dev/bin/cgi-bin/index.pl Line: 39

ERROR: OTRS-CGI-54 Perl: 5.30.0 OS: linux Time: Tue Aug 9 13:21:12 2022

 Message: Need Text!

 RemoteAddress: 10.0.2.2
 RequestURI: /Znuny-Dev/index.pl?

 Traceback (14614):
   Module: Kernel::System::TemplateGenerator::_Replace Line: 1170
   Module: Kernel::Modules::AgentTicketProcess::_RenderAjax Line: 836
   Module: Kernel::Modules::AgentTicketProcess::Run Line: 458
   Module: Kernel::System::Web::InterfaceAgent::Run Line: 1144
   Module: /opt/frameworks/Znuny-Dev/bin/cgi-bin/index.pl Line: 39

ERROR: OTRS-CGI-54 Perl: 5.30.0 OS: linux Time: Tue Aug 9 13:21:12 2022

 Message: Need AttachmentID or StandardTemplateID!

 RemoteAddress: 10.0.2.2
 RequestURI: /Znuny-Dev/index.pl?

 Traceback (14614):
   Module: Kernel::System::StdAttachment::StdAttachmentStandardTemplateMemberList Line: 561
   Module: Kernel::Modules::AgentTicketProcess::_RenderAjax Line: 842
   Module: Kernel::Modules::AgentTicketProcess::Run Line: 458
   Module: Kernel::System::Web::InterfaceAgent::Run Line: 1144
   Module: /opt/frameworks/Znuny-Dev/bin/cgi-bin/index.pl Line: 39
</details>

![StandardTemplateID](https://user-images.githubusercontent.com/80031303/183685334-6b593965-a2a4-4aef-9677-1512fd1ea8a2.gif)

This change only overwrites the body if the template selection is changed like it is the case for AgentTicketPhone.
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why this pull request should be accepted. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

1 - 🐞 bug 🐞
<!--
## Type of change
  What type of change does your PR introduce to Znuny?
  NOTE: Please add only one label with a starting '1 - ' to this PR!
  If your PR requires multiple labels to be applied, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster for the code review.

- '1 - 🆙 dependency upgrade - Dependency upgrade (e.g. libraries)
- '1 - 🐞 bug 🐞'            - Bugfix (non-breaking change which fixes an issue)
- '1 - 💎 code quality'      - Code quality improvements to existing code or addition of unit tests
- '1 - 🚀 feature'           - New feature (which adds functionality to an existing integration)
- '1 - ...'

-->

## Breaking change
<!--
  If your PR contains a breaking change, it is important
  to tell what breaks, how to make it work again and why it is necessary.
  This piece of text is published with the release notes, so it helps if you
  write it for the users, not the maintainer.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Additional information
<!--
  Details are important and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  Note: Remove this section if not needed.

  If a PR is related to an issue, please use the 'Linked issues' function on the sidebar.
-->

<!--
- This PR is related to PR: #
- ...
-->

## Checklist
<!--
  Put an 'x' in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  ❕ - nice to have
  ❗ - required before review
-->

- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [x] Local ZnunyCodePolicy run passes successfully.(❕)
- [x] Local unit tests pass.(❕)
- [x] GitHub workflow ZnunyCodePolicy passes.(❗)
- [x] GitHub workflow unit tests pass.(❗)

<!--
  Thank you for contributing ❤

  Znuny @znuny/znuny
-->
