### PR TITLE
 Fixed evaluation of parameter TicketID in Kernel::Output::HTML::Article::Base::ArticleActions (by maxence).

### DIFF
--- a/Kernel/Output/HTML/Article/Base.pm
+++ b/Kernel/Output/HTML/Article/Base.pm
@@ -178,7 +178,7 @@ sub ArticleActions {
     my $ACL = $TicketObject->TicketAcl(
         Data          => \%PossibleActions,
         Action        => 'AgentTicketZoom',
-        TicketID      => $Param{Ticket}->{TicketID},
+        TicketID      => $Param{TicketID},
         ReturnType    => 'Action',
         ReturnSubType => '-',
         UserID        => $Param{UserID},


### PR DESCRIPTION
<!--
  You are amazing! 🚀
  Thanks for contributing to the Znuny community project!
  Please, DO NOT DELETE ANY TEXT from this template (unless instructed)!

### Licensing, copyright and credits

Znuny is an open fork of an existing software. So we have to respect the already given copyright of the original creators.

New files will be licensed using the AGPL Version 3. If you contribute code to the Znuny project you will get mentioned in the pull request incl. the commit, in CHANGES.md and in AUTHORS.md. We will not mention you in the file you provided or changed. Your work is highly appreciated and acknowledged but you contribute it to the project and your copyright will pass on to the fork itself.
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why this pull request should be accepted. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Trigger was that we wanted to hide the print button in articles via ACL. This worked well in an open Ticket. However, in the Ticket Overview, e.g. by Queue, the print button was still visible in the large view.

I found the reason for this in module Article/Base.pm. Here in "sub ArticleActions" it is checked whether an ACL is active. The Ticket ID is passed here as follows:
```TicketID => $Param{Ticket}->{TicketID},```

The problem is that this parameter is passed when displaying an open ticket, but not when displaying a Ticket Overview. Therefore the print button for a ticket (or its article) is not hidden (see screenshot).
![Screenshot-1](https://user-images.githubusercontent.com/111051858/184113943-090f855c-7ca6-4a8d-ad00-30c23c017334.png)

In the call of the function "sub ArticleActions", however, it is checked whether the TicketID is passed as a parameter:
```for my $Needed (qw(TicketID ArticleID Type UserID)) {```

This means that the TicketID is present in any case, because otherwise the function is cancelled.

I therefore suggest changing the line stated above as follows:
```TicketID => $Param{TicketID},```

With this setting, the ACL will be taken into account in the Ticket Overview, i.e. the print button will be hidden (see screenshot).
![Screenshot-2](https://user-images.githubusercontent.com/111051858/184114157-13966dfd-908b-400f-ba99-dcd7a0568cc5.png)
<!--
## Type of change
  What type of change does your PR introduce to Znuny?
  NOTE: Please add only one label with a starting '1 - ' to this PR!
  If your PR requires multiple labels to be applied, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster for the code review.

- '1 - 🆙 dependency upgrade - Dependency upgrade (e.g. libraries)
- '1 - 🐞 bug 🐞'            - Bugfix (non-breaking change which fixes an issue)
- '1 - 💎 code quality'      - Code quality improvements to existing code or addition of unit tests
- '1 - 🚀 feature'           - New feature (which adds functionality to an existing integration)
- '1 - ...'

-->
1 - 🐞 bug 🐞
## Breaking change
<!--
  If your PR contains a breaking change, it is important
  to tell what breaks, how to make it work again and why it is necessary.
  This piece of text is published with the release notes, so it helps if you
  write it for the users, not the maintainer.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Additional information
<!--
  Details are important and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  Note: Remove this section if not needed.

  If a PR is related to an issue, please use the 'Linked issues' function on the sidebar.
-->

<!--
- This PR is related to PR: #
- ...
-->

## Checklist
<!--
  Put an 'x' in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  ❕ - nice to have
  ❗ - required before review
-->

- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [ ] Local ZnunyCodePolicy run passes successfully.(❕)
- [ ] Local unit tests pass.(❕)
- [ ] GitHub workflow ZnunyCodePolicy passes.(❗)
- [ ] GitHub workflow unit tests pass.(❗)

<!--
  Thank you for contributing ❤

  Znuny @znuny/znuny
-->
