### PR TITLE
Fixed visible PluginContainer (AppointmentCalendar) when empty.

### DIFF
--- a/var/httpd/htdocs/js/Core.Agent.AppointmentCalendar.js
+++ b/var/httpd/htdocs/js/Core.Agent.AppointmentCalendar.js
@@ -1794,12 +1794,17 @@ Core.Agent.AppointmentCalendar = (function (TargetNS) {
                     $PluginDataObj = $('#Plugin_' + Core.App.EscapeSelector(PluginKey) + '_LinkList'),
                     PluginData = JSON.parse($PluginDataObj.val()),
                     LinkID = $RemoveObj.data('linkId').toString(),
-                    $Parent = $RemoveObj.parent();
+                    $Parent = $RemoveObj.parent(),
+                    $PluginContainer = $Parent.parent();
 
                 PluginData.splice(PluginData.indexOf(LinkID), 1);
                 $PluginDataObj.val(JSON.stringify(PluginData));
 
                 $Parent.remove();
+                
+                if ( $PluginContainer.children().length == 0 ) {
+                    $PluginContainer.text('');
+                }
 
                 return false;
             });


### PR DESCRIPTION
<!--
  You are amazing! 🚀
  Thanks for contributing to the Znuny community project!
  Please, DO NOT DELETE ANY TEXT from this template (unless instructed)!

### Licensing, copyright and credits

Znuny is an open fork of an existing software. So we have to respect the already given copyright of the original creators.

New files will be licensed using the AGPL Version 3. If you contribute code to the Znuny project you will get mentioned in the pull request incl. the commit, in CHANGES.md and in AUTHORS.md. We will not mention you in the file you provided or changed. Your work is highly appreciated and acknowledged but you contribute it to the project and your copyright will pass on to the fork itself.
-->

## Proposed change
If an appointment already has a ticket linked to it when the dialog is opened and the Ticket gets removed, the PluginContainer will still be visible.
![image](https://user-images.githubusercontent.com/80031303/189750427-793595c8-7868-424b-a075-650fc1cd774c.png)

![image](https://user-images.githubusercontent.com/80031303/189746705-5de631d6-e8d7-4502-b94b-5b5cec69f6b9.png)
That happens because in this case the template is used to create the html. This templates contains white spaces. If the ticket entry is removed, the white spaces stay

![image](https://user-images.githubusercontent.com/80031303/189747771-fde99250-378b-4e3a-ae01-8c7efe20becf.png)

The PluginContainer is normally hidden using the pseudo selector ```:empty```. This one doesn't match white spaces though.
https://developer.mozilla.org/en-US/docs/Web/CSS/:empty

Since i couldn't find a selector that would match regardless of the white spaces, i would propose to remove the white spaces.

This visual bug is the reason for the test ```scripts/test/Selenium/Agent/AgentAppointmentLinks.t``` failing.
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why this pull request should be accepted. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

1 - 🐞 bug 🐞
<!--
## Type of change
  What type of change does your PR introduce to Znuny?
  NOTE: Please add only one label with a starting '1 - ' to this PR!
  If your PR requires multiple labels to be applied, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster for the code review.

- '1 - 🆙 dependency upgrade - Dependency upgrade (e.g. libraries)
- '1 - 🐞 bug 🐞'            - Bugfix (non-breaking change which fixes an issue)
- '1 - 💎 code quality'      - Code quality improvements to existing code or addition of unit tests
- '1 - 🚀 feature'           - New feature (which adds functionality to an existing integration)
- '1 - ...'

-->

## Breaking change
<!--
  If your PR contains a breaking change, it is important
  to tell what breaks, how to make it work again and why it is necessary.
  This piece of text is published with the release notes, so it helps if you
  write it for the users, not the maintainer.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Additional information
<!--
  Details are important and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  Note: Remove this section if not needed.

  If a PR is related to an issue, please use the 'Linked issues' function on the sidebar.
-->

<!--
- This PR is related to PR: #
- ...
-->

## Checklist
<!--
  Put an 'x' in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  ❕ - nice to have
  ❗ - required before review
-->

- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [x] Local ZnunyCodePolicy run passes successfully.(❕)
- [x] Local unit tests pass.(❕)
- [x] GitHub workflow ZnunyCodePolicy passes.(❗)
- [x] GitHub workflow unit tests pass.(❗)

<!--
  Thank you for contributing ❤

  Znuny @znuny/znuny
-->
