### PR TITLE
Sector Nord AG: Fixed bug - hour 0 is not possible in the default settings for TimeWorkingHours.

### DIFF
--- a/Kernel/System/SysConfig/ValueType/WorkingHours.pm
+++ b/Kernel/System/SysConfig/ValueType/WorkingHours.pm
@@ -190,6 +190,7 @@ sub EffectiveValueGet {
 
         HOUR:
         for my $Hour ( @{ $Component->{Item} } ) {
+            # $Hour->{Content} must be number(0-23)!
             next HOUR if $Hour->{Content} !~ m{^([0-9]|1[0-9]|2[0-3])$}msx;
 
             push @{ $Result{ $Component->{ValueName} } }, $Hour->{Content};

--- a/Kernel/System/SysConfig/ValueType/WorkingHours.pm
+++ b/Kernel/System/SysConfig/ValueType/WorkingHours.pm
@@ -190,7 +190,7 @@ sub EffectiveValueGet {
 
         HOUR:
         for my $Hour ( @{ $Component->{Item} } ) {
-            next HOUR if !$Hour->{Content};
+            next HOUR if $Hour->{Content} !~ m{^([0-9]|1[0-9]|2[0-3])$}msx;
 
             push @{ $Result{ $Component->{ValueName} } }, $Hour->{Content};
         }


### PR DESCRIPTION
<!--
  You are amazing! 🚀
  Thanks for contributing to the Znuny community project!
  Please, DO NOT DELETE ANY TEXT from this template (unless instructed)!

### Licensing, copyright and credits

Znuny is an open fork of an existing software. So we have to respect the already given copyright of the original creators.

New files will be licensed using the AGPL Version 3. If you contribute code to the Znuny project you will get mentioned in the pull request incl. the commit, in CHANGES.md and in AUTHORS.md. We will not mention you in the file you provided or changed. Your work is highly appreciated and acknowledged but you contribute it to the project and your copyright will pass on to the fork itself.
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why this pull request should be accepted. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This fixes a bug that caused the hour 0 to not be pre-selectable in the default settings.

How to reproduce the bug:
1. change the working hours in Framework.xml (should be including a 0 as Value now)
![grafik](https://user-images.githubusercontent.com/91135132/192804752-cfe85e9c-55a9-4f52-a0ed-6629638d22c9.png)
2. Maint::Config::Rebuild
3. Lookup the setting and see that 0 is not selected.


## Type of change
<!--
  What type of change does your PR introduce to Znuny?
  NOTE: Please add only one label with a starting '1 - ' to this PR!
  If your PR requires multiple labels to be applied, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster for the code review.

- '1 - 🆙 dependency upgrade - Dependency upgrade (e.g. libraries)
- '1 - 🐞 bug 🐞'            - Bugfix (non-breaking change which fixes an issue)
- '1 - 💎 code quality'      - Code quality improvements to existing code or addition of unit tests
- '1 - 🚀 feature'           - New feature (which adds functionality to an existing integration)
- '1 - ...'

-->
- '1 - 🐞 bug 🐞'            - Bugfix (non-breaking change which fixes an issue)

<!--
- This PR is related to PR: #
- ...
-->

## Checklist
<!--
  Put an 'x' in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  ❕ - nice to have
  ❗ - required before review
-->

- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [x] Local ZnunyCodePolicy run passes successfully.(❕)
- [x] Local unit tests pass.(❕)
- [x] GitHub workflow ZnunyCodePolicy passes.(❗)
- [x] GitHub workflow unit tests pass.(❗)

<!--
  Thank you for contributing ❤

  Znuny @znuny/znuny
-->
