### PR TITLE
Renamed changed Settings from FrontendRichText::Path to Frontend::RichText::Path.

### DIFF
--- a/Kernel/Config/Files/XML/Framework.xml
+++ b/Kernel/Config/Files/XML/Framework.xml
@@ -402,7 +402,7 @@
             <Item ValueType="Checkbox">1</Item>
         </Value>
     </Setting>
-    <Setting Name="Frontend::RichText::Path" Required="1" Valid="1" ConfigLevel="200">
+    <Setting Name="Frontend::RichTextPath" Required="1" Valid="1" ConfigLevel="200">
         <Description Translatable="1">Defines the URL rich text editor path.</Description>
         <Navigation>Frontend::Base</Navigation>
         <Value>

--- a/Kernel/Config/Files/XML/Framework.xml
+++ b/Kernel/Config/Files/XML/Framework.xml
@@ -402,7 +402,7 @@
             <Item ValueType="Checkbox">1</Item>
         </Value>
     </Setting>
-    <Setting Name="Frontend::RichTextPath" Required="1" Valid="1" ConfigLevel="200">
+    <Setting Name="Frontend::RichText::Path" Required="1" Valid="1" ConfigLevel="200">
         <Description Translatable="1">Defines the URL rich text editor path.</Description>
         <Navigation>Frontend::Base</Navigation>
         <Value>

--- a/Kernel/Output/HTML/Templates/Standard/CustomerFooterJS.tt
+++ b/Kernel/Output/HTML/Templates/Standard/CustomerFooterJS.tt
@@ -11,7 +11,7 @@
 <script type="text/javascript">//<![CDATA[
     "use strict";
 
-    var CKEDITOR_BASEPATH = [% Config("Frontend::RichTextPath") | JSON %];
+    var CKEDITOR_BASEPATH = [% Config("Frontend::RichText::Path") | JSON %];
 //]]></script>
 [% RenderBlockStart("CommonJS") %]
 <script type="text/javascript" src="[% Config("Frontend::JavaScriptPath") | html %][% Data.JSDirectory | html %][% Data.Filename | html %]"></script>

--- a/Kernel/Output/HTML/Templates/Standard/FooterJS.tt
+++ b/Kernel/Output/HTML/Templates/Standard/FooterJS.tt
@@ -11,7 +11,7 @@
 <script type="text/javascript">//<![CDATA[
     "use strict";
 
-    var CKEDITOR_BASEPATH = [% Config("Frontend::RichTextPath") | JSON %];
+    var CKEDITOR_BASEPATH = [% Config("Frontend::RichText::Path") | JSON %];
 //]]></script>
 [% RenderBlockStart("CommonJS") %]
 <script type="text/javascript" src="[% Config("Frontend::JavaScriptPath") | html %][% Data.JSDirectory | html %][% Data.Filename | html %]"></script>


### PR DESCRIPTION
<!--
  You are amazing! 🚀
  Thanks for contributing to the Znuny community project!
  Please, DO NOT DELETE ANY TEXT from this template (unless instructed)!

### Licensing, copyright and credits

Znuny is an open fork of an existing software. So we have to respect the already given copyright of the original creators.

New files will be licensed using the AGPL Version 3. If you contribute code to the Znuny project you will get mentioned in the pull request incl. the commit, in CHANGES.md and in AUTHORS.md. We will not mention you in the file you provided or changed. Your work is highly appreciated and acknowledged but you contribute it to the project and your copyright will pass on to the fork itself.
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why this pull request should be accepted. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixed RichText not working with JS loader enabled, which also makes the Selenium tests fail.

#285 made some changes to how Znuny loads CKEditor settings.
It unintentionally changed the setting name of the path, which is not a CKEditor setting, and is only needed to get CKEditor resources.

When the JS loader is disabled, CKEditor resolves this issue by parsing the DOM and getting the full web path of the CKEditor.
However, when the JS loader is enabled, that path does not exist, and it has no fall-back path to work with.

So, it tries to get
`otrs/lang/de.js?t=LAHF` instead of `otrs-web/js/thirdparty/ckeditor-4.17.1/plugins/image2/lang/de.js?t=LAHF`

This PR was made with @tipue-dev 🚀

## Type of change
<!--
  What type of change does your PR introduce to Znuny?
  NOTE: Please add only one label with a starting '1 - ' to this PR!
  If your PR requires multiple labels to be applied, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster for the code review.

- '1 - 🆙 dependency upgrade - Dependency upgrade (e.g. libraries)
- '1 - 🐞 bug 🐞'            - Bugfix (non-breaking change which fixes an issue)
- '1 - 💎 code quality'      - Code quality improvements to existing code or addition of unit tests
- '1 - 🚀 feature'           - New feature (which adds functionality to an existing integration)
- '1 - ...'

-->
- 1 - 🐞 bug 🐞

## Additional information
<!--
  Details are important and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  Note: Remove this section if not needed.

  If a PR is related to an issue, please use the 'Linked issues' function on the sidebar.
-->
- This PR is related to PR: #285


## Checklist
<!--
  Put an 'x' in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  ❕ - nice to have
  ❗ - required before review
-->

- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [x] Local ZnunyCodePolicy run passes successfully.(❕)
- [x] Local unit tests pass.(❕)
- [x] GitHub workflow ZnunyCodePolicy passes.(❗)
- [x] GitHub workflow unit tests pass.(❗)

<!--
  Thank you for contributing ❤

  Znuny @znuny/znuny
-->
