### PR TITLE
Fixed "NoPermission" screen to use "CustomerNoPermission" for ACL checking.

### DIFF
--- a/Kernel/Modules/CustomerTicketZoom.pm
+++ b/Kernel/Modules/CustomerTicketZoom.pm
@@ -126,7 +126,7 @@ sub Run {
 
     # show error screen if ACL prohibits this action
     if ( !$AclActionLookup{ $Self->{Action} } ) {
-        return $LayoutObject->NoPermission( WithHeader => 'yes' );
+        return $LayoutObject->CustomerNoPermission( WithHeader => 'yes' );
     }
 
     my $ArticleObject = $Kernel::OM->Get('Kernel::System::Ticket::Article');


### PR DESCRIPTION
<!--
  You are amazing! 🚀
  Thanks for contributing to the Znuny community project!
  Please, DO NOT DELETE ANY TEXT from this template (unless instructed)!

### Licensing, copyright and credits

Znuny is an open fork of an existing software. So we have to respect the already given copyright of the original creators.

New files will be licensed using the AGPL Version 3. If you contribute code to the Znuny project you will get mentioned in the pull request incl. the commit, in CHANGES.md and in AUTHORS.md. We will not mention you in the file you provided or changed. Your work is highly appreciated and acknowledged but you contribute it to the project and your copyright will pass on to the fork itself.
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why this pull request should be accepted. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

With "NoPermission" function, the customer is redirected to the agent screen, even though the URL is still the customer backend: 
https://my-znuny-host/otrs/customer.pl?Action=CustomerTicketZoom;TicketNumber=2022122196000021

The resulting permission error looks like this:

![Xnip2023-01-17_15-43-49](https://user-images.githubusercontent.com/83212096/212929018-48871296-a6f9-4005-a04d-42bb9072ecd2.png)

In other places within this module, there is already the right function "CustomerNoPermission" used.

The updated code results in a proper error message:

![Xnip2023-01-17_15-52-09](https://user-images.githubusercontent.com/83212096/212930811-1ebbdd15-f94c-4821-8dc6-ce14de00b1d4.png)

### Steps to reproduce
To reproduce this error, simply configure an ACL that filters for "Properties" -> "CustomerUser" -> "UserLogin" -> [any customer user] and next configure a "PossibleNot" -> "Action" -> "CustomerTicketZoom".
This will show the agent error message from the first screenshot when you are opening the CustomerTicketZoom for any ticket.

## Type of change
<!--
  What type of change does your PR introduce to Znuny?
  NOTE: Please add only one label with a starting '1 - ' to this PR!
  If your PR requires multiple labels to be applied, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster for the code review.

- '1 - 🆙 dependency upgrade - Dependency upgrade (e.g. libraries)
- '1 - 🐞 bug 🐞'            - Bugfix (non-breaking change which fixes an issue)
- '1 - 💎 code quality'      - Code quality improvements to existing code or addition of unit tests
- '1 - 🚀 feature'           - New feature (which adds functionality to an existing integration)
- '1 - ...'
-->
1 - 🐞 bug 🐞


## Checklist
<!--
  Put an 'x' in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  ❕ - nice to have
  ❗ - required before review
-->

- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [x] Local ZnunyCodePolicy passed.(❕)
- [x] Local UnitTests / Selenium passed.(❕)
- [x] GitHub workflow CI (UnitTests / Selenium) passed.(❗)

<!--
  Thank you for contributing ❤

  Znuny @znuny/znuny
-->
