### PR TITLE
SolutionStartResetOnReopen option added

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# 6.5.2 ????-??-??
+ - 2023-04-20 SolutionStartResetOnReopen option added.
+
 # 6.5.1 2023-03-09
  - 2023-02-28 Added options tickets-created-before-date and tickets-created-before-days to console command Admin::Article::StorageSwitch.
  - 2023-02-28 Fixed encoding of postmaster filter name in AdminPostMasterFilter.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,3 @@
-# 6.5.2 ????-??-??
- - 2023-04-20 SolutionStartResetOnReopen option added.
-
 # 6.5.1 2023-03-09
  - 2023-02-28 Added options tickets-created-before-date and tickets-created-before-days to console command Admin::Article::StorageSwitch.
  - 2023-02-28 Fixed encoding of postmaster filter name in AdminPostMasterFilter.

--- a/Kernel/Config/Files/XML/Ticket.xml
+++ b/Kernel/Config/Files/XML/Ticket.xml
@@ -134,6 +134,13 @@
             <Item ValueType="Checkbox">0</Item>
         </Value>
     </Setting>
+    <Setting Name="Ticket::SolutionStartResetOnReopen" Required="0" Valid="1">
+        <Description Translatable="1">Enable solution start time reset on ticket reopen for SLA solution time calculations.</Description>
+        <Navigation>Core::Ticket</Navigation>
+        <Value>
+            <Item ValueType="Checkbox">0</Item>
+        </Value>
+    </Setting>
     <Setting Name="Ticket::Service::Default::UnknownCustomer" Required="1" Valid="1">
         <Description Translatable="1">Allows default services to be selected also for non existing customers.</Description>
         <Navigation>Core::Ticket</Navigation>

--- a/Kernel/System/Ticket.pm
+++ b/Kernel/System/Ticket.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you


### PR DESCRIPTION
## Proposed change

With this mod you can enable SolutionStartResetOnReopen in SysConfig and SLA solution start time will be reset on every ticket reopening. When SolutionStartResetOnReopen is off, solution time is calculated like in standard Znuny - from ticket creation till first ticket closing.

## Additional information
Author-Change-Id: IB#1011372

## Type of change
- '1 - 🚀 feature'           - New feature (which adds functionality to an existing integration)

## Checklist
- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [x] Local ZnunyCodePolicy passed.(❕)
- [x] Local UnitTests / Selenium passed.(❕)
- [ ] GitHub workflow CI (UnitTests / Selenium) passed.(❗)


