### PR TITLE
Configurable shortcut icon

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,3 @@
-# 6.5.2 ????-??-??
- - 2021-05-07 Configurable shortcut icon.
-
 # 6.5.1 2023-03-09
  - 2023-02-28 Added options tickets-created-before-date and tickets-created-before-days to console command Admin::Article::StorageSwitch.
  - 2023-02-28 Fixed encoding of postmaster filter name in AdminPostMasterFilter.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# 6.5.2 ????-??-??
+ - 2021-05-07 Configurable shortcut icon.
+
 # 6.5.1 2023-03-09
  - 2023-02-28 Added options tickets-created-before-date and tickets-created-before-days to console command Admin::Article::StorageSwitch.
  - 2023-02-28 Fixed encoding of postmaster filter name in AdminPostMasterFilter.

--- a/Kernel/Config/Files/XML/Framework.xml
+++ b/Kernel/Config/Files/XML/Framework.xml
@@ -266,6 +266,13 @@
             <Item ValueType="String" ValueRegex="">Example Company</Item>
         </Value>
     </Setting>
+    <Setting Name="CustomerShortcutIcon" Required="0" Valid="0">
+        <Description Translatable="1">The shortcut icon for the customer interface.</Description>
+        <Navigation>Frontend::Customer</Navigation>
+        <Value>
+            <Item ValueType="String" ValueRegex="">/otrs-web/skins/Agent/default/img/icons/product.ico</Item>
+        </Value>
+    </Setting>
     <Setting Name="CustomerLogo" Required="0" Valid="1">
         <Description Translatable="1">The logo shown in the header of the customer interface. The URL to the image can be a relative URL to the skin image directory, or a full URL to a remote web server.</Description>
         <Navigation>Frontend::Customer</Navigation>
@@ -277,6 +284,13 @@
                 <Item Key="StyleHeight">45px</Item>
                 <Item Key="StyleWidth">216px</Item>
             </Hash>
+        </Value>
+    </Setting>
+    <Setting Name="AgentShortcutIcon" Required="0" Valid="0">
+        <Description Translatable="1">The shortcut icon for the agent interface.</Description>
+        <Navigation>Frontend::Agent</Navigation>
+        <Value>
+            <Item ValueType="String" ValueRegex="">/otrs-web/skins/Agent/default/img/icons/product.ico</Item>
         </Value>
     </Setting>
     <Setting Name="AgentLogo" Required="0" Valid="1">

--- a/Kernel/Output/HTML/Templates/Standard/CustomerHTMLHead.tt
+++ b/Kernel/Output/HTML/Templates/Standard/CustomerHTMLHead.tt
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/Output/HTML/Templates/Standard/CustomerHTMLHead.tt
+++ b/Kernel/Output/HTML/Templates/Standard/CustomerHTMLHead.tt
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -36,7 +37,11 @@
 [% RenderBlockStart("MetaLink") %]
     <link rel="[% Data.Rel | html %]" type="[% Data.Type | html %]" title="[% Data.Title | html %]" href="[% Data.Href %]" />
 [% RenderBlockEnd("MetaLink") %]
+[% IF Config("CustomerShortcutIcon") -%]
+    <link rel="shortcut icon" href="[% Config("CustomerShortcutIcon") %]" type="image/ico" />
+[% ELSE -%]
     <link rel="shortcut icon" href="[% Config("Frontend::ImagePath") %]icons/product.ico" type="image/ico" />
+[% END -%]
     <link rel="apple-touch-icon" href="[% Config("Frontend::ImagePath") %]icons/apple-touch-icon.png" />
 
 [% RenderBlockStart("CommonCSS") %]

--- a/Kernel/Output/HTML/Templates/Standard/HTMLHead.tt
+++ b/Kernel/Output/HTML/Templates/Standard/HTMLHead.tt
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -28,7 +29,11 @@
 [% RenderBlockStart("MetaLink") %]
     <link rel="[% Data.Rel | html %]" type="[% Data.Type | html %]" title="[% Data.Title | html %]" href="[% Data.Href %]" />
 [% RenderBlockEnd("MetaLink") %]
+[% IF Config("AgentShortcutIcon") -%]
+    <link rel="shortcut icon" href="[% Config("AgentShortcutIcon") %]" type="image/ico" />
+[% ELSE -%]
     <link rel="shortcut icon" href="[% Config("Frontend::ImagePath") %]icons/product.ico" type="image/ico" />
+[% END -%]
     <link rel="apple-touch-icon" href="[% Config("Frontend::ImagePath") %]icons/apple-touch-icon.png" />
 
 [% RenderBlockStart("CommonCSS") %]

--- a/Kernel/Output/HTML/Templates/Standard/HTMLHead.tt
+++ b/Kernel/Output/HTML/Templates/Standard/HTMLHead.tt
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/Output/HTML/Templates/Standard/Login.tt
+++ b/Kernel/Output/HTML/Templates/Standard/Login.tt
@@ -17,7 +17,11 @@ X-OTRS-Login: [% Env("Baselink") %]
 <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
     <meta http-equiv="Content-type" content="text/html;charset=utf-8" />
+[% IF Config("AgentShortcutIcon") -%]
+    <link rel="shortcut icon" href="[% Config("AgentShortcutIcon") %]" type="image/ico" />
+[% ELSE -%]
     <link rel="shortcut icon" href="[% Config("Frontend::ImagePath") %]icons/product.ico" type="image/ico" />
+[% END -%]
     <link rel="apple-touch-icon" href="[% Config("Frontend::ImagePath") %]icons/apple-touch-icon.png" />
 
 [% RenderBlockStart("CommonCSS") %]


### PR DESCRIPTION
## Proposed change

This mod introduces two new SysConfig parameters

* AgentShortcutIcon
* CustomerShortcutIcon

that allow one to specify shortcut icons to use in Znuny agent
and customer panel.

## Type of change

- '1 - 🚀 feature'           - New feature (which adds functionality to an existing integration)

## Additional information

Related: https://github.com/OTRS/otrs/pull/1426
Author-Change-Id: IB#1046319

## Checklist
- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [x] You improved or added new unit tests.(❕)
- [x] Local ZnunyCodePolicy passed.(❕)
- [x] Local UnitTests / Selenium passed.(❕)
- [ ] GitHub workflow CI (UnitTests / Selenium) passed.(❗)
