### PR TITLE
Blocking external content using CSP enhanced

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,3 @@
-# 6.5.2 ????-??-??
- - 2023-04-22 Blocking external content using CSP enhanced.
-
 # 6.5.1 2023-03-09
  - 2023-02-28 Added options tickets-created-before-date and tickets-created-before-days to console command Admin::Article::StorageSwitch.
  - 2023-02-28 Fixed encoding of postmaster filter name in AdminPostMasterFilter.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# 6.5.2 ????-??-??
+ - 2023-04-22 Blocking external content using CSP enhanced.
+
 # 6.5.1 2023-03-09
  - 2023-02-28 Added options tickets-created-before-date and tickets-created-before-days to console command Admin::Article::StorageSwitch.
  - 2023-02-28 Fixed encoding of postmaster filter name in AdminPostMasterFilter.

--- a/Kernel/Modules/AgentTicketArticleContent.pm
+++ b/Kernel/Modules/AgentTicketArticleContent.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/Modules/AgentTicketArticleContent.pm
+++ b/Kernel/Modules/AgentTicketArticleContent.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -170,7 +171,7 @@ sub Run {
     # return html attachment
     return $LayoutObject->Attachment(
         %Data,
-        Sandbox => 1,
+        Sandbox => $LoadExternalImages ? 2 : 1,  # Block external content with CSP also (allow only images if required).
     );
 }
 

--- a/Kernel/Modules/CustomerTicketArticleContent.pm
+++ b/Kernel/Modules/CustomerTicketArticleContent.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -194,7 +195,7 @@ sub Run {
     # return html attachment
     return $LayoutObject->Attachment(
         %Data,
-        Sandbox => 1,
+        Sandbox => $LoadExternalImages ? 2 : 1,  # Block external content with CSP also (allow only images if required).    
     );
 }
 

--- a/Kernel/Modules/CustomerTicketArticleContent.pm
+++ b/Kernel/Modules/CustomerTicketArticleContent.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/Modules/CustomerTicketArticleContent.pm
+++ b/Kernel/Modules/CustomerTicketArticleContent.pm
@@ -195,7 +195,7 @@ sub Run {
     # return html attachment
     return $LayoutObject->Attachment(
         %Data,
-        Sandbox => $LoadExternalImages ? 2 : 1,  # Block external content with CSP also (allow only images if required).    
+        Sandbox => $LoadExternalImages ? 2 : 1,  # Block external content with CSP also (allow only images if required).
     );
 }
 

--- a/Kernel/Output/HTML/Layout.pm
+++ b/Kernel/Output/HTML/Layout.pm
@@ -2694,7 +2694,7 @@ sub Attachment {
         # referrer:   don't send referrers to prevent referrer-leak attacks
         $Output
             .= "Content-Security-Policy: default-src 'self'; img-src "
-            . (($Param{Sandbox} == 2) ? "*" : "'self'")
+            . ( ( $Param{Sandbox} == 2 ) ? "*" : "'self'" )
             . " data:; script-src 'none'; object-src 'self'; frame-src 'none'; style-src 'unsafe-inline'; referrer no-referrer;\n";
 
         # Use Referrer-Policy header to suppress referrer information in modern browsers


### PR DESCRIPTION
## Proposed change

CPS header changed to better block loading external content.

Znuny tries to filter external content in HTML e-mails using perl regexps; this way its difficult
to predict and block all HTML/JS/CSS quirks, i.e. Znuny does not block remote image loading
if used in CSS like this

    <div style="background:url('http://badspammer.com/tracking/1/TrackRead.aspx?mail_id=1F4CA3DD-24E0-4C14-B631-A7567EAA5D83')"></div>

which may allow spammers to notice that their junk was read by receiver.

Using `Content Security Policy` described on http://www.html5rocks.com/en/tutorials/security/content-security-policy/
seems to be proper way of blocking external content in iframes.
According to https://content-security-policy.com/ it should work fine in modern browsers.

This mod adds

    Content-Security-Policy: default-src 'self'; style-src 'unsafe-inline'

HTTP header for iframes with HTML e-mails which forces modern web browsers to block all external and inline content except
inline styling (used often in html e-mails). CSP header is not added if user explicitly unlocks external
content using link provided by Znuny.

In future it may be good idea to drop Znuny own filtering to offload this task from busy application servers
(parsing huge HTML content may cause problems...) to web browsers.

## Type of change

- '1 - 🚀 feature'           - New feature (which adds functionality to an existing integration)

## Additional information

Related: https://github.com/OTRS/otrs/pull/1501
Author-Change-Id: IB#1047017

## Checklist

- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [x] You improved or added new unit tests.(❕)
- [x] Local ZnunyCodePolicy passed.(❕)
- [x] Local UnitTests / Selenium passed.(❕)
- [ ] GitHub workflow CI (UnitTests / Selenium) passed.(❗)
