### PR TITLE
System configuration: Added `NotificationEmailDefaultTemplate` option.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# 6.5.2 ????-??-??
+ - 2023-04-24 NotificationEmailDefaultTemplate option added.
+
 # 6.5.1 2023-03-09
  - 2023-02-28 Added options tickets-created-before-date and tickets-created-before-days to console command Admin::Article::StorageSwitch.
  - 2023-02-28 Fixed encoding of postmaster filter name in AdminPostMasterFilter.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,3 @@
-# 6.5.2 ????-??-??
- - 2023-04-24 NotificationEmailDefaultTemplate option added.
-
 # 6.5.1 2023-03-09
  - 2023-02-28 Added options tickets-created-before-date and tickets-created-before-days to console command Admin::Article::StorageSwitch.
  - 2023-02-28 Fixed encoding of postmaster filter name in AdminPostMasterFilter.

--- a/Kernel/Config/Files/XML/Framework.xml
+++ b/Kernel/Config/Files/XML/Framework.xml
@@ -7944,6 +7944,13 @@ via the Preferences button after logging in.
             <Item ValueType="Checkbox">0</Item>
         </Value>
     </Setting>
+    <Setting Name="NotificationEmailDefaultTemplate" Required="0" Valid="1">
+        <Description Translatable="1">Default template for notification e-mails (see Kernel/Output/HTML/Templates/Standard/NotificationEvent/Email directory for available templates).</Description>
+        <Navigation>Core</Navigation>
+        <Value>
+            <Item ValueType="String" ValueRegex="">Default</Item>
+        </Value>
+    </Setting>
     <Setting Name="Loader::Enabled::CSS" Required="1" Valid="1">
         <Description Translatable="1">If enabled, OTRS will deliver all CSS files in minified form.</Description>
         <Navigation>Frontend::Base::Loader</Navigation>

--- a/Kernel/System/Ticket/Event/NotificationEvent/Transport/Email.pm
+++ b/Kernel/System/Ticket/Event/NotificationEvent/Transport/Email.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -125,10 +126,11 @@ sub SendNotification {
 
     if ( $Param{Notification}->{ContentType} && $Param{Notification}->{ContentType} eq 'text/html' ) {
 
-        # Get configured template with fallback to Default.
-        my $EmailTemplate = $Param{Notification}->{Data}->{TransportEmailTemplate}->[0] || 'Default';
+        # Get configured template with fallback to default.
+        my $EmailTemplate = $Param{Notification}->{Data}->{TransportEmailTemplate}->[0]
+            || $ConfigObject->Get('NotificationEmailDefaultTemplate') || 'Default';
 
-        my $Home              = $Kernel::OM->Get('Kernel::Config')->Get('Home');
+        my $Home              = $ConfigObject->Get('Home');
         my $TemplateDir       = "$Home/Kernel/Output/HTML/Templates/Standard/NotificationEvent/Email";
         my $CustomTemplateDir = "$Home/Custom/Kernel/Output/HTML/Templates/Standard/NotificationEvent/Email";
 
@@ -401,7 +403,8 @@ sub TransportSettingsDisplayGet {
         $Param{$Key} = $Param{Data}->{$Key}->[0];
     }
 
-    my $Home              = $Kernel::OM->Get('Kernel::Config')->Get('Home');
+    my $ConfigObject      = $Kernel::OM->Get('Kernel::Config');
+    my $Home              = $ConfigObject->Get('Home');
     my $TemplateDir       = "$Home/Kernel/Output/HTML/Templates/Standard/NotificationEvent/Email";
     my $CustomTemplateDir = "$Home/Custom/Kernel/Output/HTML/Templates/Standard/NotificationEvent/Email";
 
@@ -431,7 +434,7 @@ sub TransportSettingsDisplayGet {
         Data        => \%Templates,
         Name        => 'TransportEmailTemplate',
         Translation => 0,
-        SelectedID  => $Param{Data}->{TransportEmailTemplate} || 'Default',
+        SelectedID  => $Param{Data}->{TransportEmailTemplate} || $ConfigObject->Get('NotificationEmailDefaultTemplate') || 'Default',
         Class       => 'Modernize W50pc',
     );
 

--- a/Kernel/System/Ticket/Event/NotificationEvent/Transport/Email.pm
+++ b/Kernel/System/Ticket/Event/NotificationEvent/Transport/Email.pm
@@ -434,8 +434,10 @@ sub TransportSettingsDisplayGet {
         Data        => \%Templates,
         Name        => 'TransportEmailTemplate',
         Translation => 0,
-        SelectedID  => $Param{Data}->{TransportEmailTemplate} || $ConfigObject->Get('NotificationEmailDefaultTemplate') || 'Default',
-        Class       => 'Modernize W50pc',
+        SelectedID  => $Param{Data}->{TransportEmailTemplate}
+            || $ConfigObject->Get('NotificationEmailDefaultTemplate')
+            || 'Default',
+        Class => 'Modernize W50pc',
     );
 
     # security fields

--- a/Kernel/System/Ticket/Event/NotificationEvent/Transport/Email.pm
+++ b/Kernel/System/Ticket/Event/NotificationEvent/Transport/Email.pm
@@ -440,9 +440,6 @@ sub TransportSettingsDisplayGet {
 
     # security fields
 
-    # get config object
-    my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
-
     my %SecuritySignEncryptOptions;
 
     if ( $ConfigObject->Get('PGP') ) {

--- a/Kernel/System/Ticket/Event/NotificationEvent/Transport/Email.pm
+++ b/Kernel/System/Ticket/Event/NotificationEvent/Transport/Email.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you


### PR DESCRIPTION
## Proposed change

This mod introduces new SysConfig parameter

NotificationEmailDefaultTemplate

that allowes one to specify default template (from
Kernel/Output/HTML/Templates/Standard/NotificationEvent/Email
directory) to use when sending notification e-mails.

## Type of change
- '1 - 🚀 feature'           - New feature (which adds functionality to an existing integration)

## Additional information

Related: https://github.com/OTRS/otrs/pull/1081
Author-Change-Id: IB#1050091

## Checklist
- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [x] Local ZnunyCodePolicy passed.(❕)
- [x] Local UnitTests / Selenium passed.(❕)
- [ ] GitHub workflow CI (UnitTests / Selenium) passed.(❗)
