### PR TITLE
Follow up detection based on Message-ID e-mail header

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,3 @@
-# 6.5.2 ????-??-??
- - 2023-04-24 Added follow up detection based on Message-ID e-mail header.
-
 # 6.5.1 2023-03-09
  - 2023-02-28 Added options tickets-created-before-date and tickets-created-before-days to console command Admin::Article::StorageSwitch.
  - 2023-02-28 Fixed encoding of postmaster filter name in AdminPostMasterFilter.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# 6.5.2 ????-??-??
+ - 2023-04-24 Added follow up detection based on Message-ID e-mail header.
+
 # 6.5.1 2023-03-09
  - 2023-02-28 Added options tickets-created-before-date and tickets-created-before-days to console command Admin::Article::StorageSwitch.
  - 2023-02-28 Fixed encoding of postmaster filter name in AdminPostMasterFilter.

--- a/Kernel/Config/Files/XML/Ticket.xml
+++ b/Kernel/Config/Files/XML/Ticket.xml
@@ -11747,6 +11747,17 @@ Thanks for your help!
             </Hash>
         </Value>
     </Setting>
+    <Setting Name="PostMaster::CheckFollowUpModule###0600-MessageID" Required="0" Valid="0">
+        <Description Translatable="1">Executes follow up Message-ID checks in mails that don't have a ticket number in the subject. Incoming message will be treated as ticket X follow up if: (0) Message-ID is not empty (should not be) and (1) there is 1 or more (but not more than MaxArticles if MaxArticles is greater than 0) articles in ticket X with the same Message-ID and (2) no article with the same Message-ID exists in ticket other than X and (3) age difference between oldest Article from (1) and incoming message is not greater than MaxAge seconds if MaxAge greater than 0.</Description>
+        <Navigation>Core::Email::PostMaster</Navigation>
+        <Value>
+            <Hash>
+                <Item Key="Module">Kernel::System::PostMaster::FollowUpCheck::MessageID</Item>
+                <Item Key="MaxAge">604800</Item>
+                <Item Key="MaxArticles">10</Item>
+            </Hash>
+        </Value>
+    </Setting>
     <Setting Name="PostMaster::NewTicket::AutoAssignCustomerIDForUnknownCustomers" Required="1" Valid="1">
         <Description Translatable="1">Controls if CustomerID is automatically copied from the sender address for unknown customers.</Description>
         <Navigation>Core::Email::PostMaster</Navigation>

--- a/Kernel/System/PostMaster.pm
+++ b/Kernel/System/PostMaster.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/System/PostMaster/FollowUpCheck/MessageID.pm
+++ b/Kernel/System/PostMaster/FollowUpCheck/MessageID.pm
@@ -1,0 +1,85 @@
+# --
+# Copyright (C) 2016-2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (GPL). If you
+# did not receive this file, see https://www.gnu.org/licenses/gpl-3.0.txt.
+# --
+
+package Kernel::System::PostMaster::FollowUpCheck::MessageID;
+## nofilter(TidyAll::Plugin::Znuny::Legal::UpdateZnunyCopyright)
+
+use strict;
+use warnings;
+
+our @ObjectDependencies = (
+    'Kernel::System::Log',
+    'Kernel::System::Ticket',
+);
+
+sub new {
+    my ( $Type, %Param ) = @_;
+
+    # Allocate new hash for object.
+    my $Self = {};
+    bless( $Self, $Type );
+
+    # Get communication log object.
+    $Self->{CommunicationLogObject} = $Param{CommunicationLogObject} || die "Got no CommunicationLogObject!";
+
+    return $Self;
+}
+
+sub Run {
+    my ( $Self, %Param ) = @_;
+
+    $Self->{CommunicationLogObject}->ObjectLog(
+        ObjectLogType => 'Message',
+        Priority      => 'Debug',
+        Key           => 'Kernel::System::PostMaster::FollowUpCheck::MessageID',
+        Value         => 'Searching for existing TicketID using Message-ID header.',
+    );
+
+    # Checking mandatory configuration options.
+    for my $Option (qw(MaxAge MaxArticles)) {
+        if ( !defined $Param{JobConfig}->{$Option} || !$Param{JobConfig}->{$Option} ) {
+            $Kernel::OM->Get('Kernel::System::Log')->Log(
+                Priority => 'error',
+                Message  => "Missing configuration for $Option for postmaster MessageID follow-up check module.",
+            );
+            return;
+        }
+    }
+
+    # Do ticket lookup using Message-ID; for details see
+    # PostMaster::CheckFollowUpModule###0600-MessageID description in SysConfig.
+    if ( $Param{GetParam}->{'Message-ID'} ) {
+        my $ArticleBackendObject = $Kernel::OM->Get('Kernel::System::Ticket::Article')->BackendForChannel(
+            ChannelName => 'Email',
+        );
+
+        # Get ticket id containing article(s) with given message id.
+        my $TicketID = $ArticleBackendObject->ArticleGetTicketIDByMessageID(
+            MessageID              => $Param{GetParam}->{'Message-ID'},
+            MaxAge                 => $Param{JobConfig}->{MaxAge},
+            MaxArticles            => $Param{JobConfig}->{MaxArticles},
+            Quiet                  => $Param{Quiet},
+            CommunicationLogObject => $Self->{CommunicationLogObject},
+        );
+
+        if ($TicketID) {
+            $Self->{CommunicationLogObject}->ObjectLog(
+                ObjectLogType => 'Message',
+                Priority      => 'Debug',
+                Key           => 'Kernel::System::PostMaster::FollowUpCheck::MessageID',
+                Value         => "Found valid TicketID '$TicketID' using email Message-ID.",
+            );
+
+            return $TicketID;
+        }
+    }
+
+    return;
+}
+
+1;

--- a/Kernel/System/PostMaster/FollowUpCheck/MessageID.pm
+++ b/Kernel/System/PostMaster/FollowUpCheck/MessageID.pm
@@ -13,6 +13,7 @@ use strict;
 use warnings;
 
 our @ObjectDependencies = (
+    'Kernel::System::Ticket::Article',
     'Kernel::System::Log',
     'Kernel::System::Ticket',
 );

--- a/Kernel/System/PostMaster/FollowUpCheck/References.pm
+++ b/Kernel/System/PostMaster/FollowUpCheck/References.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -52,20 +53,22 @@ sub Run {
 
     for my $Reference (@References) {
 
-        my %Article = $ArticleBackendObject->ArticleGetByMessageID(
-            MessageID => "<$Reference>",
+        # Get ticket id containing article(s) with given message id.
+        my $TicketID = $ArticleBackendObject->ArticleGetTicketIDByMessageID(
+            MessageID              => "<$Reference>",
+            Quiet                  => $Param{Quiet},
+            CommunicationLogObject => $Self->{CommunicationLogObject},
         );
 
-        if (%Article) {
-
+        if ($TicketID) {
             $Self->{CommunicationLogObject}->ObjectLog(
                 ObjectLogType => 'Message',
                 Priority      => 'Debug',
                 Key           => 'Kernel::System::PostMaster::FollowUpCheck::References',
-                Value         => "Found valid TicketID '$Article{TicketID}' in email references.",
+                Value         => "Found valid TicketID '$TicketID' using email references.",
             );
 
-            return $Article{TicketID};
+            return $TicketID;
         }
     }
 

--- a/Kernel/System/PostMaster/FollowUpCheck/References.pm
+++ b/Kernel/System/PostMaster/FollowUpCheck/References.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/System/Ticket/Article/Backend/Email.pm
+++ b/Kernel/System/Ticket/Article/Backend/Email.pm
@@ -284,7 +284,7 @@ sub ArticleGetTicketIDByMessageID {
 
         # Oldest article is older than MaxAge seconds?
         if (
-              $Kernel::OM->Create('Kernel::System::DateTime')->ToEpoch()
+            $Kernel::OM->Create('Kernel::System::DateTime')->ToEpoch()
             - $Param{MaxAge}
             > $OldestArticleCreateTime
             )

--- a/Kernel/System/Ticket/Article/Backend/Email.pm
+++ b/Kernel/System/Ticket/Article/Backend/Email.pm
@@ -219,7 +219,7 @@ sub ArticleGetTicketIDByMessageID {
                 INNER JOIN article_data_mime sadm ON sa.id = sadm.article_id
                 WHERE sadm.a_message_id_md5 = ?
             ',
-            Bind  => [ \$MD5 ],
+            Bind => [ \$MD5 ],
         );
 
         $Count = 0;
@@ -230,7 +230,7 @@ sub ArticleGetTicketIDByMessageID {
         if ( $Count >= $Param{MaxArticles} ) {
             if ( !$Quiet ) {
                 my $Message = "Number of articles with Message-ID '$Param{MessageID}' ($Count) "
-                        . "reached MaxArticles limit (" . $Param{MaxArticles} . ")";
+                    . "reached MaxArticles limit (" . $Param{MaxArticles} . ")";
                 if ( $Param{CommunicationLogObject} ) {
                     $Param{CommunicationLogObject}->ObjectLog(
                         ObjectLogType => 'Message',
@@ -283,8 +283,12 @@ sub ArticleGetTicketIDByMessageID {
         )->ToEpoch();
 
         # Oldest article is older than MaxAge seconds?
-        if ( $Kernel::OM->Create('Kernel::System::DateTime')->ToEpoch() - $Param{MaxAge}
-            > $OldestArticleCreateTime ) {
+        if (
+              $Kernel::OM->Create('Kernel::System::DateTime')->ToEpoch()
+            - $Param{MaxAge}
+            > $OldestArticleCreateTime
+            )
+        {
             if ( !$Quiet ) {
                 my $Message = "Oldest article with Message-ID '$Param{MessageID}' is "
                     . "older (" . $OldestArticleCreate . ") than MaxAge limit ("

--- a/Kernel/System/Ticket/Article/Backend/Email.pm
+++ b/Kernel/System/Ticket/Article/Backend/Email.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -60,9 +61,10 @@ sub ChannelNameGet {
 Return article data by supplied message ID.
 
     my %Article = $ArticleBackendObject->ArticleGetByMessageID(
-        MessageID     => '<13231231.1231231.32131231@example.com>',     # (required)
-        DynamicFields => 1,                                             # (optional) To include the dynamic field values for this article on the return structure.
-        RealNames     => 1,                                             # (optional) To include the From/To/Cc/Bcc fields with real names.
+        MessageID              => '<13231231.1231231.32131231@example.com>',     # (required)
+        DynamicFields          => 1,                                             # (optional) To include the dynamic field values for this article on the return structure.
+        RealNames              => 1,                                             # (optional) To include the From/To/Cc/Bcc fields with real names.
+        CommunicationLogObject => $Self->{CommunicationLogObject}                # If set use it to log messages.
     );
 
 =cut
@@ -104,19 +106,210 @@ sub ArticleGetByMessageID {
     return if $Count == 0;
     return if !$Param{TicketID} || !$Param{ArticleID};
 
-    # More than one reference found! That should not happen, since 'a message_id' should be unique!
+    # Return empty search result if more than one article with given Message-ID found.
     if ( $Count > 1 ) {
-        $Kernel::OM->Get('Kernel::System::Log')->Log(
-            Priority => 'notice',
-            Message =>
-                "The MessageID '$Param{MessageID}' is in your database more than one time! That should not happen, since 'a message_id' should be unique!",
-        );
+        my $Message = "More than one article with Message-ID '$Param{MessageID}' exists.";
+        if ( $Param{CommunicationLogObject} ) {
+            $Param{CommunicationLogObject}->ObjectLog(
+                ObjectLogType => 'Message',
+                Priority      => 'Debug',
+                Key           => 'Kernel::System::Ticket::Article::Backend::Email',
+                Value         => $Message,
+            );
+        }
+        else {
+            $Kernel::OM->Get('Kernel::System::Log')->Log(
+                Priority => 'notice',
+                Message  => $Message,
+            );
+        }
         return;
     }
 
     return $Self->ArticleGet(
         %Param,
     );
+}
+
+=head2 ArticleGetTicketIDByMessageID()
+
+Get ticket id of given message ID.
+
+    my $TicketID = $ArticleBackendObject->ArticleGetTicketIDByMessageID(
+        MessageID              => '<13231231.1231231.32131231@example.com>',  # (required)
+        MaxAge                 => 0,                                          # Search only articles not older than MaxAge
+                                                                              # seconds; 0 disables this filter.
+        MaxArticles            => 0,                                          # Search failure if more than MaxArticles have
+                                                                              # same Message-ID; 0 disables this filter.
+        Quiet                  => 0,                                          # 1 = don't generate logs for prerun
+
+        CommunicationLogObject => $Self->{CommunicationLogObject}             # If set use it to log messages.
+    );
+
+=cut
+
+sub ArticleGetTicketIDByMessageID {
+    my ( $Self, %Param ) = @_;
+
+    if ( !$Param{MessageID} ) {
+        $Kernel::OM->Get('Kernel::System::Log')->Log(
+            Priority => 'error',
+            Message  => 'Need MessageID!',
+        );
+        return;
+    }
+
+    my $Quiet = $Param{Quiet} // 0;
+
+    my $MD5 = $Kernel::OM->Get('Kernel::System::Main')->MD5sum( String => $Param{MessageID} );
+
+    my $DBObject = $Kernel::OM->Get('Kernel::System::DB');
+
+    # Get tickets with e-mail articles with given Message-ID.
+    return if !$DBObject->Prepare(
+        SQL => '
+            SELECT DISTINCT(sa.ticket_id) FROM article sa
+            INNER JOIN article_data_mime sadm ON sa.id = sadm.article_id
+            WHERE sadm.a_message_id_md5 = ?
+        ',
+        Bind  => [ \$MD5 ],
+        Limit => 2,
+    );
+
+    my $TicketID;
+    my $Count = 0;
+    while ( my @Row = $DBObject->FetchrowArray() ) {
+        $Count++;
+        $TicketID = $Row[0];
+    }
+
+    # No ticket found.
+    return if $Count == 0;
+
+    # Search failure if more than one ticket with article having given Message-ID exist.
+    if ( $Count > 1 ) {
+        if ( !$Quiet ) {
+            my $Message = "Articles with Message-ID '$Param{MessageID}' exist in more than one ticket.";
+            if ( $Param{CommunicationLogObject} ) {
+                $Param{CommunicationLogObject}->ObjectLog(
+                    ObjectLogType => 'Message',
+                    Priority      => 'Debug',
+                    Key           => 'Kernel::System::Ticket::Article::Backend::Email',
+                    Value         => $Message,
+                );
+            }
+            else {
+                $Kernel::OM->Get('Kernel::System::Log')->Log(
+                    Priority => 'notice',
+                    Message  => $Message,
+                );
+            }
+        }
+        return;
+    }
+
+    # Search failure if number of articles with given Message-ID is greater than MaxArticles
+    # (disable check if MaxArticles is not integer or is not > 0).
+    if ( $Param{MaxArticles} && ( $Param{MaxArticles} =~ /^\d+$/ ) && ( $Param{MaxArticles} > 0 ) ) {
+
+        # Get number of articles with given Message-ID.
+        return if !$DBObject->Prepare(
+            SQL => '
+                SELECT COUNT(sa.id) FROM article sa
+                INNER JOIN article_data_mime sadm ON sa.id = sadm.article_id
+                WHERE sadm.a_message_id_md5 = ?
+            ',
+            Bind  => [ \$MD5 ],
+        );
+
+        $Count = 0;
+        while ( my @Row = $DBObject->FetchrowArray() ) {
+            $Count = $Row[0];
+        }
+
+        if ( $Count >= $Param{MaxArticles} ) {
+            if ( !$Quiet ) {
+                my $Message = "Number of articles with Message-ID '$Param{MessageID}' ($Count) "
+                        . "reached MaxArticles limit (" . $Param{MaxArticles} . ")";
+                if ( $Param{CommunicationLogObject} ) {
+                    $Param{CommunicationLogObject}->ObjectLog(
+                        ObjectLogType => 'Message',
+                        Priority      => 'Debug',
+                        Key           => 'Kernel::System::Ticket::Article::Backend::Email',
+                        Value         => $Message,
+                    );
+                }
+                else {
+                    $Kernel::OM->Get('Kernel::System::Log')->Log(
+                        Priority => 'notice',
+                        Message  => $Message,
+                    );
+                }
+            }
+            return;
+        }
+    }
+
+    # Search failure if oldest article with given Message-ID is older than MaxAge seconds
+    # (disable check if MaxAge is not integer or is not > 0).
+    if ( $Param{MaxAge} && ( $Param{MaxAge} =~ /^\d+$/ ) && ( $Param{MaxAge} > 0 ) ) {
+
+        # Get create time of oldest article with given Message-ID.
+
+        return if !$DBObject->Prepare(
+            SQL => '
+                SELECT sa.create_time FROM article sa
+                INNER JOIN article_data_mime sadm ON sa.id = sadm.article_id
+                WHERE sadm.a_message_id_md5 = ? ORDER BY create_time ASC
+            ',
+            Bind  => [ \$MD5 ],
+            Limit => 1,
+        );
+
+        my $OldestArticleCreate = 0;
+        while ( my @Row = $DBObject->FetchrowArray() ) {
+            $OldestArticleCreate = $Row[0];
+
+            # Cleanup time stamps (some databases are using e. g. 2008-02-25 22:03:00.000000
+            # and 0000-00-00 00:00:00 time stamps).
+            $OldestArticleCreate =~ s/^(\d\d\d\d-\d\d-\d\d\s\d\d:\d\d:\d\d)\..+?$/$1/;
+        }
+
+        my $OldestArticleCreateTime = $Kernel::OM->Create(
+            'Kernel::System::DateTime',
+            ObjectParams => {
+                String => $OldestArticleCreate,
+            }
+        )->ToEpoch();
+
+        # Oldest article is older than MaxAge seconds?
+        if ( $Kernel::OM->Create('Kernel::System::DateTime')->ToEpoch() - $Param{MaxAge}
+            > $OldestArticleCreateTime ) {
+            if ( !$Quiet ) {
+                my $Message = "Oldest article with Message-ID '$Param{MessageID}' is "
+                    . "older (" . $OldestArticleCreate . ") than MaxAge limit ("
+                    . $Param{MaxAge} . " sec.).";
+                if ( $Param{CommunicationLogObject} ) {
+                    $Param{CommunicationLogObject}->ObjectLog(
+                        ObjectLogType => 'Message',
+                        Priority      => 'Debug',
+                        Key           => 'Kernel::System::Ticket::Article::Backend::Email',
+                        Value         => $Message,
+                    );
+                }
+                else {
+                    $Kernel::OM->Get('Kernel::System::Log')->Log(
+                        Priority => 'notice',
+                        Message  => $Message
+                    );
+                }
+            }
+            return;
+        }
+    }
+
+    return $TicketID;
+
 }
 
 =head2 ArticleSend()

--- a/Kernel/System/Ticket/Article/Backend/Email.pm
+++ b/Kernel/System/Ticket/Article/Backend/Email.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you


### PR DESCRIPTION
## Proposed change

Znuny creates separate tickets if one sends same e-mail message to
a few Znuny system addresses (i.e. using multiple Znuny system
addresses in To/Cc/Bcc in the same e-mail message) . It may be
difficult to notice such duplicates in bigger Znuny systems
and same request be processed by different agents.

This mod introduces SysConfig parameter
`PostMaster::CheckFollowUpModule###0600-MessageID`
that allowes Znuny to merge messages with the same Message-ID
into one ticket. To avoid merging too many messages into one
ticket (in case of Message-ID generation problem at sender side)
or merging new messages to very old tickets in case of
Message-ID duplicates in wider time, two module parameters
are provided:

* `MaxAge` - time (in seconds) from the first article with
   given Message-ID creation, after which new messages with
   the same Message-ID won't be merged into the same ticket
   any more,

* `MaxArticles` - number of messages with the same
   Message-ID in Znuny database after which next e-mail messages
   with the same Message-ID won't be merged into the same ticket
   any more.

For example: with MaxAge=604800 and MaxArticles=10 Znuny will merge
into one ticket up to 10 messages with the same Message-ID if all
will arrive in the same week.

## Type of change
- '1 - 🚀 feature'           - New feature (which adds functionality to an existing integration)

## Additional information

Related: https://github.com/OTRS/otrs/pull/1170
Author-Change-Id: IB#1051946

## Checklist
- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [x] Local ZnunyCodePolicy passed.(❕)
- [x] Local UnitTests / Selenium passed.(❕)
- [ ] GitHub workflow CI (UnitTests / Selenium) passed.(❗)
