### PR TITLE
Both types of move possible using MoveType parameter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# 6.5.2 ????-??-??
+ - 2023-04-24 Both types of move possible using MoveType parameter.
+
 # 6.5.1 2023-03-09
  - 2023-02-28 Added options tickets-created-before-date and tickets-created-before-days to console command Admin::Article::StorageSwitch.
  - 2023-02-28 Fixed encoding of postmaster filter name in AdminPostMasterFilter.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,3 @@
-# 6.5.2 ????-??-??
- - 2023-04-24 Both types of move possible using MoveType parameter.
-
 # 6.5.1 2023-03-09
  - 2023-02-28 Added options tickets-created-before-date and tickets-created-before-days to console command Admin::Article::StorageSwitch.
  - 2023-02-28 Fixed encoding of postmaster filter name in AdminPostMasterFilter.

--- a/Kernel/Config/Files/XML/Ticket.xml
+++ b/Kernel/Config/Files/XML/Ticket.xml
@@ -4472,12 +4472,13 @@
         </Value>
     </Setting>
     <Setting Name="Ticket::Frontend::MoveType" Required="1" Valid="1">
-        <Description Translatable="1">Determines if the list of possible queues to move to ticket into should be displayed in a dropdown list or in a new window in the agent interface. If "New Window" is set you can add a move note to the ticket.</Description>
+        <Description Translatable="1">Determines if the list of possible queues to move to ticket into should be displayed in a dropdown list or in a new window in the agent interface or both. If "New window" is set you can add a move note to the ticket.</Description>
         <Navigation>Frontend::Agent::View::TicketMove</Navigation>
         <Value>
             <Item ValueType="Select" SelectedID="form">
-                <Item ValueType="Option" Value="link" Translatable="1">New Window</Item>
+                <Item ValueType="Option" Value="link" Translatable="1">New window</Item>
                 <Item ValueType="Option" Value="form" Translatable="1">Dropdown</Item>
+                <Item ValueType="Option" Value="linkandform" Translatable="1">Dropdown and new window</Item>
             </Item>
         </Value>
     </Setting>
@@ -5839,7 +5840,7 @@
             </Hash>
         </Value>
     </Setting>
-    <Setting Name="Ticket::Frontend::PreMenuModule###445-Move" Required="0" Valid="1">
+    <Setting Name="Ticket::Frontend::PreMenuModule###445-MoveLink" Required="0" Valid="1">
         <Description Translatable="1">Shows a link in the menu to move a ticket in every ticket overview of the agent interface.</Description>
         <Navigation>Frontend::Agent::TicketOverview::MenuModule</Navigation>
         <Value>
@@ -5848,6 +5849,20 @@
                 <Item Key="Name" Translatable="1">Move</Item>
                 <Item Key="Action">AgentTicketMove</Item>
                 <Item Key="Description" Translatable="1">Change queue!</Item>
+                <Item Key="MoveType">link</Item>
+            </Hash>
+        </Value>
+    </Setting>
+    <Setting Name="Ticket::Frontend::PreMenuModule###446-MoveForm" Required="0" Valid="1">
+        <Description Translatable="1">Shows a form in the menu to move a ticket in every ticket overview of the agent interface.</Description>
+        <Navigation>Frontend::Agent::TicketOverview::MenuModule</Navigation>
+        <Value>
+            <Hash>
+                <Item Key="Module">Kernel::Output::HTML::TicketMenu::Move</Item>
+                <Item Key="Name" Translatable="1">Move</Item>
+                <Item Key="Action">AgentTicketMove</Item>
+                <Item Key="Description" Translatable="1">Change queue!</Item>
+                <Item Key="MoveType">form</Item>
             </Hash>
         </Value>
     </Setting>
@@ -8746,7 +8761,7 @@
         <Description Translatable="1">Sets the default subject for notes added in the ticket move screen of the agent interface.</Description>
         <Navigation>Frontend::Agent::View::TicketMove</Navigation>
         <Value>
-            <Item ValueType="String" ValueRegex=""></Item>
+            <Item ValueType="String" ValueRegex="">Queue change</Item>
         </Value>
     </Setting>
     <Setting Name="Ticket::Frontend::AgentTicketMove###Body" UserPreferencesGroup="Advanced" UserModificationPossible="1" Required="0" Valid="1">

--- a/Kernel/Modules/AgentTicketMove.pm
+++ b/Kernel/Modules/AgentTicketMove.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/Modules/AgentTicketMove.pm
+++ b/Kernel/Modules/AgentTicketMove.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -158,7 +159,7 @@ sub Run {
     for my $Parameter (
         qw(Subject Body
         NewUserID NewStateID NewPriorityID
-        OwnerAll NoSubmit DestQueueID DestQueue
+        OwnerAll NoSubmit DestQueueID DestQueue MoveType
         StandardTemplateID CreateArticle FormDraftID Title
         )
         )
@@ -1225,7 +1226,7 @@ sub Run {
     # only set the dynamic fields if the new window was displayed (link), otherwise if ticket was
     # moved from the dropdown menu (form) in AgentTicketZoom, the value if the dynamic fields will
     # be undefined and it will set to empty in the DB, see bug#8481
-    if ( $ConfigObject->Get('Ticket::Frontend::MoveType') eq 'link' ) {
+    if ( $GetParam{MoveType} ne 'form' ) {
 
         # cycle trough the activated Dynamic Fields for this screen
         DYNAMICFIELD:
@@ -1290,12 +1291,12 @@ sub Run {
     if ( !$AccessNew || $NextScreen eq 'LastScreenOverview' ) {
 
         # Module directly called
-        if ( $ConfigObject->Get('Ticket::Frontend::MoveType') eq 'form' ) {
+        if ( $GetParam{MoveType} eq 'form' ) {
             return $LayoutObject->Redirect( OP => $Self->{LastScreenOverview} );
         }
 
         # Module opened in popup
-        elsif ( $ConfigObject->Get('Ticket::Frontend::MoveType') eq 'link' ) {
+        else {
             return $LayoutObject->PopupClose(
                 URL => ( $Self->{LastScreenOverview} || 'Action=AgentDashboard' ),
             );
@@ -1303,7 +1304,7 @@ sub Run {
     }
 
     # Module directly called
-    if ( $ConfigObject->Get('Ticket::Frontend::MoveType') eq 'form' ) {
+    if ( $GetParam{MoveType} eq 'form' ) {
         return $LayoutObject->Redirect(
             OP => "Action=AgentTicketZoom;TicketID=$Self->{TicketID}"
                 . ( $ArticleID ? ";ArticleID=$ArticleID" : '' ),
@@ -1311,7 +1312,7 @@ sub Run {
     }
 
     # Module opened in popup
-    elsif ( $ConfigObject->Get('Ticket::Frontend::MoveType') eq 'link' ) {
+    else {
         return $LayoutObject->PopupClose(
             URL => "Action=AgentTicketZoom;TicketID=$Self->{TicketID}"
                 . ( $ArticleID ? ";ArticleID=$ArticleID" : '' ),

--- a/Kernel/Modules/AgentTicketZoom.pm
+++ b/Kernel/Modules/AgentTicketZoom.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -1342,7 +1343,7 @@ sub MaskAgentZoom {
     }
 
     # get MoveQueuesStrg
-    if ( $ConfigObject->Get('Ticket::Frontend::MoveType') =~ /^form$/i ) {
+    if ( $ConfigObject->Get('Ticket::Frontend::MoveType') =~ /form/i ) {
         $MoveQueues{0}         = '- ' . $LayoutObject->{LanguageObject}->Translate('Move') . ' -';
         $Param{MoveQueuesStrg} = $LayoutObject->AgentQueueListOption(
             Name           => 'DestQueueID',
@@ -1365,13 +1366,14 @@ sub MaskAgentZoom {
         );
         $Param{TicketID} = $Ticket{TicketID};
         if ($Access) {
-            if ( $ConfigObject->Get('Ticket::Frontend::MoveType') =~ /^form$/i ) {
+            if ( $ConfigObject->Get('Ticket::Frontend::MoveType') =~ /form/i ) {
                 $LayoutObject->Block(
                     Name => 'MoveLink',
                     Data => { %Param, %AclAction },
                 );
             }
-            else {
+
+            if ( $ConfigObject->Get('Ticket::Frontend::MoveType') =~ /link/i ) {
                 $LayoutObject->Block(
                     Name => 'MoveForm',
                     Data => { %Param, %AclAction },

--- a/Kernel/Modules/AgentTicketZoom.pm
+++ b/Kernel/Modules/AgentTicketZoom.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketOverviewMedium.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketOverviewMedium.tt
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketOverviewMedium.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketOverviewMedium.tt
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -292,6 +293,7 @@
         <input type="hidden" name="Action" value="AgentTicketMove"/>
         <input type="hidden" name="QueueID" value="[% Data.QueueID | html %]"/>
         <input type="hidden" name="TicketID" value="[% Data.TicketID | html %]"/>
+        <input type="hidden" name="MoveType" value="form"/>
         <label for="DestQueueID" class="InvisibleText">[% Translate("Change queue") | html %]:</label>
         [% Data.MoveQueuesStrg %]
     </form>

--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketOverviewPreview.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketOverviewPreview.tt
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketOverviewPreview.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketOverviewPreview.tt
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -292,6 +293,7 @@
         <input type="hidden" name="Action" value="AgentTicketMove"/>
         <input type="hidden" name="QueueID" value="[% Data.QueueID | html %]"/>
         <input type="hidden" name="TicketID" value="[% Data.TicketID | html %]"/>
+        <input type="hidden" name="MoveType" value="form"/>
         <label for="DestQueueID" class="InvisibleText">[% Translate("Change queue") | html %]:</label>
         [% Data.MoveQueuesStrg %]
     </form>

--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketOverviewSmall.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketOverviewSmall.tt
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -369,6 +370,7 @@
         <input type="hidden" name="Action" value="AgentTicketMove"/>
         <input type="hidden" name="QueueID" value="[% Data.QueueID | html %]"/>
         <input type="hidden" name="TicketID" value="[% Data.TicketID | html %]"/>
+        <input type="hidden" name="MoveType" value="form"/>
         <label for="DestQueueID" class="InvisibleText">[% Translate("Change queue") | html %]:</label>
         [% Data.MoveQueuesStrg %]
     </form>

--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketOverviewSmall.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketOverviewSmall.tt
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketZoom.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketZoom.tt
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -176,22 +177,23 @@
                                 </form>
                             </li>
 [% RenderBlockEnd("TicketMenuPhoneAsDropdown") %]
+[% RenderBlockStart("MoveForm") %]
+                            <li>
+                                <a href="[% Env("Baselink") %]Action=AgentTicketMove;TicketID=[% Data.TicketID | uri %];" class="AsPopup PopupType_TicketAction" title="[% Translate("Change Queue") | html %]">[% Translate("Move") | html %]</a>
+                            </li>
+[% RenderBlockEnd("MoveForm") %]
 [% RenderBlockStart("MoveLink") %]
                             <li class="[% Data.Class | html %]">
                                 <form title="[% Translate("Move ticket to a different queue") | html %]" action="[% Env("CGIHandle") | html %]" method="post">
                                     <input type="hidden" name="Action" value="AgentTicketMove"/>
                                     <input type="hidden" name="QueueID" value="[% Data.QueueID | html %]"/>
                                     <input type="hidden" name="TicketID" value="[% Data.TicketID | html %]"/>
+                                    <input type="hidden" name="MoveType" value="form"/>
                                     <label for="DestQueueID" class="InvisibleText">[% Translate("Queue") | html %]:</label>
                                     [% Data.MoveQueuesStrg %]
                                 </form>
                             </li>
 [% RenderBlockEnd("MoveLink") %]
-[% RenderBlockStart("MoveForm") %]
-                            <li>
-                                <a href="[% Env("Baselink") %]Action=AgentTicketMove;TicketID=[% Data.TicketID | uri %];" class="AsPopup PopupType_TicketAction" title="[% Translate("Change Queue") | html %]">[% Translate("Queue") | html %]</a>
-                            </li>
-[% RenderBlockEnd("MoveForm") %]
 [% RenderBlockStart("TicketMenuExternalLink") %]
                             <li>
                                 <a href="[% Data.Link | Interpolate %]" class="[% Data.Class | html %]" [% Data.LinkParam %] title="[% Translate(Data.Description) | html %]" target="[% Data.Target %]">[% Translate(Data.Name) | html %]</a>

--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketZoom.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketZoom.tt
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/Output/HTML/TicketMenu/Move.pm
+++ b/Kernel/Output/HTML/TicketMenu/Move.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/Output/HTML/TicketMenu/Move.pm
+++ b/Kernel/Output/HTML/TicketMenu/Move.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -107,29 +108,41 @@ sub Run {
 
     $Param{Link} = 'Action=AgentTicketMove;TicketID=[% Data.TicketID | uri %];';
 
-    if ( $ConfigObject->Get('Ticket::Frontend::MoveType') =~ /^form$/i ) {
-        $Param{Target} = '';
-        $Param{Block}  = 'DocumentMenuItemMoveForm';
+    if ( $Param{Config}->{MoveType} && $Param{Config}->{MoveType} =~ /form/i ) {
 
-        # get layout object
-        my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
+        if ( $ConfigObject->Get('Ticket::Frontend::MoveType') =~ /form/i ) {
+            $Param{Target} = '';
+            $Param{Block}  = 'DocumentMenuItemMoveForm';
 
-        # get move queues
-        my %MoveQueues = $TicketObject->MoveList(
-            TicketID => $Param{Ticket}->{TicketID},
-            UserID   => $Self->{UserID},
-            Action   => $LayoutObject->{Action},
-            Type     => 'move_into',
-        );
-        $MoveQueues{0}         = '- ' . $LayoutObject->{LanguageObject}->Translate('Move') . ' -';
-        $Param{MoveQueuesStrg} = $LayoutObject->AgentQueueListOption(
-            Name  => 'DestQueueID',
-            Data  => \%MoveQueues,
-            Class => 'Modernize',
-        );
+            # Get layout object.
+            my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
+
+            # Get move queues.
+            my %MoveQueues = $TicketObject->MoveList(
+                TicketID => $Param{Ticket}->{TicketID},
+                UserID   => $Self->{UserID},
+                Action   => $LayoutObject->{Action},
+                Type     => 'move_into',
+            );
+            $MoveQueues{0} = '- ' . $LayoutObject->{LanguageObject}->Translate('Move') . ' -';
+            $Param{MoveQueuesStrg} = $LayoutObject->AgentQueueListOption(
+                Name  => 'DestQueueID',
+                Data  => \%MoveQueues,
+                Class => 'Modernize',
+            );
+        }
+        else {
+            return;
+        }
     }
-    else {
-        $Param{PopupType} = 'TicketAction';
+
+    if ( $Param{Config}->{MoveType} && $Param{Config}->{MoveType} =~ /link/i ) {
+        if ( $ConfigObject->Get('Ticket::Frontend::MoveType' ) =~ /link/i ) {
+            $Param{PopupType} = 'TicketAction';
+        }
+        else {
+             return;
+        }
     }
 
     # return item

--- a/Kernel/Output/HTML/TicketMenu/Move.pm
+++ b/Kernel/Output/HTML/TicketMenu/Move.pm
@@ -124,7 +124,7 @@ sub Run {
                 Action   => $LayoutObject->{Action},
                 Type     => 'move_into',
             );
-            $MoveQueues{0} = '- ' . $LayoutObject->{LanguageObject}->Translate('Move') . ' -';
+            $MoveQueues{0}         = '- ' . $LayoutObject->{LanguageObject}->Translate('Move') . ' -';
             $Param{MoveQueuesStrg} = $LayoutObject->AgentQueueListOption(
                 Name  => 'DestQueueID',
                 Data  => \%MoveQueues,
@@ -137,11 +137,11 @@ sub Run {
     }
 
     if ( $Param{Config}->{MoveType} && $Param{Config}->{MoveType} =~ /link/i ) {
-        if ( $ConfigObject->Get('Ticket::Frontend::MoveType' ) =~ /link/i ) {
+        if ( $ConfigObject->Get('Ticket::Frontend::MoveType') =~ /link/i ) {
             $Param{PopupType} = 'TicketAction';
         }
         else {
-             return;
+            return;
         }
     }
 


### PR DESCRIPTION
## Proposed change

Both types of move possible using MoveType parameter

This mod extends `Ticket::Frontend::MoveType` SysConfig parameter
with new value Dropdown and new window that allows one to use
both move operation types (dropdown and dialog) together.

With Dropdown and new window setting agents can easily choose
if they want to move ticket with comment using dialog or
to do just fast move using dropdown.


## Type of change
- '1 - 🚀 feature'           - New feature (which adds functionality to an existing integration)

## Additional information

Related: https://github.com/OTRS/otrs/pull/1316
Author-Change-Id: IB#1053415

## Checklist
- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [x] Local ZnunyCodePolicy passed.(❕)
- [x] Local UnitTests / Selenium passed.(❕)
- [ ] GitHub workflow CI (UnitTests / Selenium) passed.(❗)
