### PR TITLE
Configurable resolver timeout

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# 6.5.2 ????-??-??
+ - 2023-04-24 Configurable resolver timeout.
+
 # 6.5.1 2023-03-09
  - 2023-02-28 Added options tickets-created-before-date and tickets-created-before-days to console command Admin::Article::StorageSwitch.
  - 2023-02-28 Fixed encoding of postmaster filter name in AdminPostMasterFilter.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,3 @@
-# 6.5.2 ????-??-??
- - 2023-04-24 Configurable resolver timeout.
-
 # 6.5.1 2023-03-09
  - 2023-02-28 Added options tickets-created-before-date and tickets-created-before-days to console command Admin::Article::StorageSwitch.
  - 2023-02-28 Fixed encoding of postmaster filter name in AdminPostMasterFilter.

--- a/Kernel/Config/Files/XML/Framework.xml
+++ b/Kernel/Config/Files/XML/Framework.xml
@@ -576,6 +576,13 @@
             <Item ValueType="String" ValueRegex="">ns.example.com</Item>
         </Value>
     </Setting>
+    <Setting Name="ResolverTimeout" Required="0" Valid="0">
+        <Description Translatable="1">Sets the timeout (in seconds) for resolver DNS queries (i.e. during checking MX record if CheckMXRecord is enabled to protect against long agent UI responses in case of very slow DNS queries).</Description>
+        <Navigation>Core::Email</Navigation>
+        <Value>
+            <Item ValueType="String" ValueRegex="">3</Item>
+        </Value>
+    </Setting>
     <Setting Name="CheckEmailAddresses" Required="1" Valid="1">
         <Description Translatable="1">Makes the application check the syntax of email addresses.</Description>
         <Navigation>Core::Email</Navigation>

--- a/Kernel/System/CheckItem.pm
+++ b/Kernel/System/CheckItem.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/System/CheckItem.pm
+++ b/Kernel/System/CheckItem.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -147,8 +148,9 @@ sub CheckEmail {
         if ($Resolver) {
 
             # it's no fun to have this hanging in the web interface
-            $Resolver->tcp_timeout(3);
-            $Resolver->udp_timeout(3);
+            my $ResolverTimeout = $ConfigObject->Get('ResolverTimeout') // 3;
+            $Resolver->tcp_timeout($ResolverTimeout);
+            $Resolver->udp_timeout($ResolverTimeout);
 
             # check if we need to use a specific name server
             my $Nameserver = $ConfigObject->Get('CheckMXRecord::Nameserver');


### PR DESCRIPTION
## Proposed change

Znuny uses hardcoded 3s timeout for DNS queries while checking MX
(if CheckMXRecord is enabled). 3s may be too short in some scenarios
(sporadic errors in MX validation of remote addresses). DNS timeout
should be configurable to allow admin to fine-tune this setting.

This mod introduces new SysConfig parameter ResolverTimeout that
allows one to set custom timeout for DNS queries fired by Znuny
(now only for CheckMXRecord algo).

## Type of change
- '1 - 🚀 feature'           - New feature (which adds functionality to an existing integration)

## Additional information

Related: https://github.com/OTRS/otrs/pull/1524
Author-Change-Id: IB#1058919

## Checklist
- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [x] Local ZnunyCodePolicy passed.(❕)
- [x] Local UnitTests / Selenium passed.(❕)
- [ ] GitHub workflow CI (UnitTests / Selenium) passed.(❗)
