### PR TITLE
Znuny daemon task start/finish message logging added

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,3 @@
-# 6.5.2 ????-??-??
- - 2023-04-25 Daemon task start/finish message logging added.
-
 # 6.5.1 2023-03-09
  - 2023-02-28 Added options tickets-created-before-date and tickets-created-before-days to console command Admin::Article::StorageSwitch.
  - 2023-02-28 Fixed encoding of postmaster filter name in AdminPostMasterFilter.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# 6.5.2 ????-??-??
+ - 2023-04-25 Daemon task start/finish message logging added.
+
 # 6.5.1 2023-03-09
  - 2023-02-28 Added options tickets-created-before-date and tickets-created-before-days to console command Admin::Article::StorageSwitch.
  - 2023-02-28 Fixed encoding of postmaster filter name in AdminPostMasterFilter.

--- a/Kernel/System/Daemon/DaemonModules/SchedulerTaskWorker.pm
+++ b/Kernel/System/Daemon/DaemonModules/SchedulerTaskWorker.pm
@@ -131,7 +131,6 @@ sub PreRun {
 sub Run {
     my ( $Self, %Param ) = @_;
 
-
     $Self->{CurrentWorkersCount} = scalar keys %{ $Self->{CurrentWorkers} };
 
     my @TaskList = $Self->{SchedulerDBObject}->TaskListUnlocked();

--- a/Kernel/System/Daemon/DaemonModules/SchedulerTaskWorker.pm
+++ b/Kernel/System/Daemon/DaemonModules/SchedulerTaskWorker.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you


### PR DESCRIPTION
## Proposed change

This mod adds Znuny daemon task start/finish message logging
which may be useful for monitoring daemon condition
and problem analysis.

## Type of change
- '1 - 🚀 feature'           - New feature (which adds functionality to an existing integration)

## Additional information

Related: https://github.com/OTRS/otrs/pull/1748
Author-Change-Id: IB#1069324

## Checklist

- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [x] Local ZnunyCodePolicy passed.(❕)
- [x] Local UnitTests / Selenium passed.(❕)
- [ ] GitHub workflow CI (UnitTests / Selenium) passed.(❗)
