### PR TITLE
Configurable access to archive searching in agent panel

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# 6.5.2 ????-??-??
+ - 2023-04-25 Configurable access to archive searching in agent panel.
+
 # 6.5.1 2023-03-09
  - 2023-02-28 Added options tickets-created-before-date and tickets-created-before-days to console command Admin::Article::StorageSwitch.
  - 2023-02-28 Fixed encoding of postmaster filter name in AdminPostMasterFilter.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,3 @@
-# 6.5.2 ????-??-??
- - 2023-04-25 Configurable access to archive searching in agent panel.
-
 # 6.5.1 2023-03-09
  - 2023-02-28 Added options tickets-created-before-date and tickets-created-before-days to console command Admin::Article::StorageSwitch.
  - 2023-02-28 Fixed encoding of postmaster filter name in AdminPostMasterFilter.

--- a/Kernel/Config/Files/XML/Ticket.xml
+++ b/Kernel/Config/Files/XML/Ticket.xml
@@ -162,6 +162,13 @@
             <Item ValueType="Checkbox">1</Item>
         </Value>
     </Setting>
+    <Setting Name="Ticket::ArchiveSearchUserGroup" Required="0" Valid="0">
+        <Description Translatable="1">Name of group that user must belog to (rw), to be able to search ticket archive (does not affect generic agent nor statistics modules). If not defined - all users are able to search ticket archive.</Description>
+        <Navigation>Core::Ticket</Navigation>
+        <Value>
+            <Item ValueType="String" ValueRegex=""></Item>
+        </Value>
+    </Setting>
     <Setting Name="Ticket::CustomerArchiveSystem" Required="1" Valid="1">
         <Description Translatable="1">Activates the ticket archive system search in the customer interface.</Description>
         <Navigation>Core::Ticket</Navigation>

--- a/Kernel/Modules/AgentTicketSearch.pm
+++ b/Kernel/Modules/AgentTicketSearch.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/Modules/AgentTicketSearch.pm
+++ b/Kernel/Modules/AgentTicketSearch.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -1656,12 +1657,43 @@ sub Run {
         );
 
         if ( $ConfigObject->Get('Ticket::ArchiveSystem') ) {
-            push @Attributes, (
-                {
-                    Key   => 'SearchInArchive',
-                    Value => Translatable('Archive Search'),
-                },
-            );
+
+            # Allow archive searching if Ticket::ArchiveSearchUserGroup is not defined.
+            my $ArchiveSearchAllowed = 1;
+
+            if ( $ConfigObject->Get('Ticket::ArchiveSearchUserGroup') ) {
+
+                # If Ticket::ArchiveSearchUserGroup is defined, allow archive searching
+                # only if user does has rw access to Ticket::ArchiveSearchUserGroup group.
+
+                $ArchiveSearchAllowed = 0;
+
+                my $GroupObject = $Kernel::OM->Get('Kernel::System::Group');
+
+                # Get current user groups.
+                my %UserGroups = $GroupObject->GroupMemberList(
+                    UserID => $Self->{UserID},
+                    Type   => 'rw',
+                    Result => 'HASH',
+                );
+
+                # Get group id of Ticket::ArchiveSearchUserGroup.
+                my $ArchiveSearchUserGroupID =
+                    $GroupObject->GroupLookup( Group => $ConfigObject->Get('Ticket::ArchiveSearchUserGroup') );
+
+                if ( defined $ArchiveSearchUserGroupID && $UserGroups{$ArchiveSearchUserGroupID} ) {
+                    $ArchiveSearchAllowed = 1;
+                }
+            }
+
+            if ( $ArchiveSearchAllowed ) {
+                push @Attributes, (
+                    {
+                        Key   => 'SearchInArchive',
+                        Value => Translatable('Archive Search'),
+                    },
+                );
+            }
         }
 
         # Dynamic fields
@@ -1975,16 +2007,47 @@ sub Run {
 
         if ( $ConfigObject->Get('Ticket::ArchiveSystem') ) {
 
-            $Param{SearchInArchiveStrg} = $LayoutObject->BuildSelection(
-                Data => {
-                    ArchivedTickets    => Translatable('Archived tickets'),
-                    NotArchivedTickets => Translatable('Unarchived tickets'),
-                    AllTickets         => Translatable('All tickets'),
-                },
-                Name       => 'SearchInArchive',
-                SelectedID => $GetParam{SearchInArchive} || 'NotArchivedTickets',
-                Class      => 'Modernize',
-            );
+            # Allow archive searching if Ticket::ArchiveSearchUserGroup is not defined.
+            my $ArchiveSearchAllowed = 1;
+
+            if ( $ConfigObject->Get('Ticket::ArchiveSearchUserGroup') ) {
+
+                # If Ticket::ArchiveSearchUserGroup is defined, allow archive searching
+                # only if user does has rw access to Ticket::ArchiveSearchUserGroup group.
+
+                $ArchiveSearchAllowed = 0;
+
+                my $GroupObject = $Kernel::OM->Get('Kernel::System::Group');
+
+                # Get current user groups.
+                my %UserGroups = $GroupObject->GroupMemberList(
+                    UserID => $Self->{UserID},
+                    Type   => 'rw',
+                    Result => 'HASH',
+                );
+
+                # Get group id of Ticket::ArchiveSearchUserGroup.
+                my $ArchiveSearchUserGroupID =
+                    $GroupObject->GroupLookup( Group => $ConfigObject->Get('Ticket::ArchiveSearchUserGroup') );
+
+                if ( defined $ArchiveSearchUserGroupID && $UserGroups{$ArchiveSearchUserGroupID} ) {
+                    $ArchiveSearchAllowed = 1;
+                }
+            }
+
+            if ( $ArchiveSearchAllowed ) {
+
+                $Param{SearchInArchiveStrg} = $LayoutObject->BuildSelection(
+                    Data => {
+                        ArchivedTickets    => Translatable('Archived tickets'),
+                        NotArchivedTickets => Translatable('Unarchived tickets'),
+                        AllTickets         => Translatable('All tickets'),
+                    },
+                    Name       => 'SearchInArchive',
+                    SelectedID => $GetParam{SearchInArchive} || 'NotArchivedTickets',
+                    Class      => 'Modernize',
+                );
+            }
         }
 
         my %Profiles = $SearchProfileObject->SearchProfileList(

--- a/Kernel/Modules/AgentTicketSearch.pm
+++ b/Kernel/Modules/AgentTicketSearch.pm
@@ -1686,7 +1686,7 @@ sub Run {
                 }
             }
 
-            if ( $ArchiveSearchAllowed ) {
+            if ($ArchiveSearchAllowed) {
                 push @Attributes, (
                     {
                         Key   => 'SearchInArchive',
@@ -2035,7 +2035,7 @@ sub Run {
                 }
             }
 
-            if ( $ArchiveSearchAllowed ) {
+            if ($ArchiveSearchAllowed) {
 
                 $Param{SearchInArchiveStrg} = $LayoutObject->BuildSelection(
                     Data => {

--- a/Kernel/Output/HTML/LinkObject/Ticket.pm
+++ b/Kernel/Output/HTML/LinkObject/Ticket.pm
@@ -836,7 +836,7 @@ sub SearchOptionList {
             }
         }
 
-        if ( $ArchiveSearchAllowed ) {
+        if ($ArchiveSearchAllowed) {
             push @SearchOptionList,
                 {
                 Key  => 'ArchiveID',

--- a/Kernel/Output/HTML/LinkObject/Ticket.pm
+++ b/Kernel/Output/HTML/LinkObject/Ticket.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/Output/HTML/LinkObject/Ticket.pm
+++ b/Kernel/Output/HTML/LinkObject/Ticket.pm
@@ -26,6 +26,7 @@ our @ObjectDependencies = (
     'Kernel::System::CustomerUser',
     'Kernel::System::DynamicField',
     'Kernel::System::DynamicField::Backend',
+    'Kernel::System::Group',
     'Kernel::System::JSON',
     'Kernel::System::Log',
     'Kernel::System::Priority',


### PR DESCRIPTION
## Proposed change

This mod introduces new SysConfig parameter Ticket::ArchiveSearchUserGroup
that allowes archive searching only if user has rw access to group specified
in its value (no restriction if Ticket::ArchiveSearchUserGroup is not defined).

## Type of change
- '1 - 🚀 feature'           - New feature (which adds functionality to an existing integration)

## Additional information

Related: https://github.com/OTRS/otrs/pull/1847
Author-Change-Id: IB#1073066

## Checklist
- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [x] Local ZnunyCodePolicy passed.(❕)
- [x] Local UnitTests / Selenium passed.(❕)
- [ ] GitHub workflow CI (UnitTests / Selenium) passed.(❗)
