### PR TITLE
Redundant article search index rebuilding fixed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# 6.5.2 ????-??-??
+ - 2023-04-25 Fixed article search index redundant update on every article create.
+
 # 6.5.1 2023-03-09
  - 2023-02-28 Added options tickets-created-before-date and tickets-created-before-days to console command Admin::Article::StorageSwitch.
  - 2023-02-28 Fixed encoding of postmaster filter name in AdminPostMasterFilter.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,3 @@
-# 6.5.2 ????-??-??
- - 2023-04-25 Fixed article search index redundant update on every article create.
-
 # 6.5.1 2023-03-09
  - 2023-02-28 Added options tickets-created-before-date and tickets-created-before-days to console command Admin::Article::StorageSwitch.
  - 2023-02-28 Fixed encoding of postmaster filter name in AdminPostMasterFilter.

--- a/Kernel/System/Console/Command/Maint/Ticket/FulltextIndexRebuildWorker.pm
+++ b/Kernel/System/Console/Command/Maint/Ticket/FulltextIndexRebuildWorker.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/System/Console/Command/Maint/Ticket/FulltextIndexRebuildWorker.pm
+++ b/Kernel/System/Console/Command/Maint/Ticket/FulltextIndexRebuildWorker.pm
@@ -180,6 +180,13 @@ sub ArticleIndexRebuild {
                         ArticleID => $ArticleID,
                         UserID    => 1,
                     );
+
+                    if ( $Success ) {
+                        $ArticleObject->ArticleSearchIndexRebuildFlagSet(
+                            ArticleIDs => [$ArticleID],
+                            Value      => 0,
+                        );
+                    }
                 }
                 else {
                     $Success = $ArticleObject->ArticleSearchIndexBuild(
@@ -187,6 +194,8 @@ sub ArticleIndexRebuild {
                         ArticleID => $ArticleID,
                         UserID    => 1,
                     );
+                    # ArticleSearchIndexBuild() removes rebuild flag on rebuilding
+                    # success, so no need to do it here.
                 }
 
                 if ( !$Success ) {

--- a/Kernel/System/Console/Command/Maint/Ticket/FulltextIndexRebuildWorker.pm
+++ b/Kernel/System/Console/Command/Maint/Ticket/FulltextIndexRebuildWorker.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -192,12 +193,6 @@ sub ArticleIndexRebuild {
                     $Kernel::OM->Get('Kernel::System::Log')->Log(
                         Priority => 'error',
                         Message  => "Could not rebuild index for ArticleID '$ArticleID'!"
-                    );
-                }
-                else {
-                    $ArticleObject->ArticleSearchIndexRebuildFlagSet(
-                        ArticleIDs => [$ArticleID],
-                        Value      => 0,
                     );
                 }
             }

--- a/Kernel/System/Console/Command/Maint/Ticket/FulltextIndexRebuildWorker.pm
+++ b/Kernel/System/Console/Command/Maint/Ticket/FulltextIndexRebuildWorker.pm
@@ -181,7 +181,7 @@ sub ArticleIndexRebuild {
                         UserID    => 1,
                     );
 
-                    if ( $Success ) {
+                    if ($Success) {
                         $ArticleObject->ArticleSearchIndexRebuildFlagSet(
                             ArticleIDs => [$ArticleID],
                             Value      => 0,
@@ -194,6 +194,7 @@ sub ArticleIndexRebuild {
                         ArticleID => $ArticleID,
                         UserID    => 1,
                     );
+
                     # ArticleSearchIndexBuild() removes rebuild flag on rebuilding
                     # success, so no need to do it here.
                 }

--- a/Kernel/System/Ticket/Article.pm
+++ b/Kernel/System/Ticket/Article.pm
@@ -931,13 +931,16 @@ sub ArticleSearchIndexBuild {
 
     # Don't build index, unset rebuild flag and return indexing failure if ticket is archived
     # and archived ticket indexing is disabled.
-    if ( $ConfigObject->Get('Ticket::ArchiveSystem')
+    if (
+        $ConfigObject->Get('Ticket::ArchiveSystem')
         && !$ConfigObject->Get('Ticket::SearchIndex::IndexArchivedTickets')
-        && $Kernel::OM->Get('Kernel::System::Ticket')->TicketArchiveFlagGet( TicketID => $Param{TicketID} ) ) {
+        && $Kernel::OM->Get('Kernel::System::Ticket')->TicketArchiveFlagGet( TicketID => $Param{TicketID} )
+        )
+    {
 
         $Self->ArticleSearchIndexRebuildFlagSet(
-             ArticleIDs => [$Param{ArticleID}],
-             Value      => 0,
+            ArticleIDs => [ $Param{ArticleID} ],
+            Value      => 0,
         );
 
         return;
@@ -947,8 +950,8 @@ sub ArticleSearchIndexBuild {
 
         # Unset articles search index rebuild flag after successfull rebuild.
         $Self->ArticleSearchIndexRebuildFlagSet(
-             ArticleIDs => [$Param{ArticleID}],
-             Value      => 0,
+            ArticleIDs => [ $Param{ArticleID} ],
+            Value      => 0,
         );
         return 1;
     }

--- a/Kernel/System/Ticket/Article.pm
+++ b/Kernel/System/Ticket/Article.pm
@@ -917,7 +917,7 @@ Returns:
 sub ArticleSearchIndexBuild {
     my ( $Self, %Param ) = @_;
 
-    for my $Needed (qw(ArticleID)) {
+    for my $Needed (qw(TicketID ArticleID)) {
         if ( !$Param{$Needed} ) {
             $Kernel::OM->Get('Kernel::System::Log')->Log(
                 Priority => 'error',
@@ -925,6 +925,22 @@ sub ArticleSearchIndexBuild {
             );
             return;
         }
+    }
+
+    my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+
+    # Don't build index, unset rebuild flag and return indexing failure if ticket is archived
+    # and archived ticket indexing is disabled.
+    if ( $ConfigObject->Get('Ticket::ArchiveSystem')
+        && !$ConfigObject->Get('Ticket::SearchIndex::IndexArchivedTickets')
+        && $Kernel::OM->Get('Kernel::System::Ticket')->TicketArchiveFlagGet( TicketID => $Param{TicketID} ) ) {
+
+        $Self->ArticleSearchIndexRebuildFlagSet(
+             ArticleIDs => [$Param{ArticleID}],
+             Value      => 0,
+        );
+
+        return;
     }
 
     if ( $Kernel::OM->Get( $Self->{ArticleSearchIndexModule} )->ArticleSearchIndexBuild(%Param) ) {

--- a/Kernel/System/Ticket/Article.pm
+++ b/Kernel/System/Ticket/Article.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/System/Ticket/Article.pm
+++ b/Kernel/System/Ticket/Article.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -916,7 +917,27 @@ Returns:
 sub ArticleSearchIndexBuild {
     my ( $Self, %Param ) = @_;
 
-    return $Kernel::OM->Get( $Self->{ArticleSearchIndexModule} )->ArticleSearchIndexBuild(%Param);
+    for my $Needed (qw(ArticleID)) {
+        if ( !$Param{$Needed} ) {
+            $Kernel::OM->Get('Kernel::System::Log')->Log(
+                Priority => 'error',
+                Message  => "Need $Needed!"
+            );
+            return;
+        }
+    }
+
+    if ( $Kernel::OM->Get( $Self->{ArticleSearchIndexModule} )->ArticleSearchIndexBuild(%Param) ) {
+
+        # Unset articles search index rebuild flag after successfull rebuild.
+        $Self->ArticleSearchIndexRebuildFlagSet(
+             ArticleIDs => [$Param{ArticleID}],
+             Value      => 0,
+        );
+        return 1;
+    }
+
+    return;
 }
 
 =head2 ArticleSearchIndexDelete()


### PR DESCRIPTION
## Proposed change

Article search index is rebuild twice:

(1) in ArticleCreate (ArticleSearchIndexBuild called)

and

(2) by FulltextIndexRebuildWorker.pm task called from otrs.Daemon
(because articles are created in article table with default value
in search_index_needs_rebuild column which is 1).

This is waste of resouces and may cause unnecessarry data
fragmentation in search index backends.

This mod resolves this issue by unflagging article for search
index rebuilding after successfull index rebuild.

To be considered for future versions (not included in this mod):
change article.search_index_needs_rebuild default value in DB
schema to 0 to avoid possible races with otrs.Daemon trying to
update article search index just after insert to article table
in ArticleCreate and before ArticleCreate calls
ArticleSearchIndexBuild.

## Type of change

- '1 - 🐞 bug 🐞'            - Bugfix (non-breaking change which fixes an issue)

## Additional information

Replaces: https://github.com/znuny/Znuny/pull/62
Author-Change-Id: IB#1108194

## Checklist
- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [x] Local ZnunyCodePolicy passed.(❕)
- [x] Local UnitTests / Selenium passed.(❕)
- [ ] GitHub workflow CI (UnitTests / Selenium) passed.(❗)
