### PR TITLE
Allow to disable executing Kernel::System::SupportDataCollector::PluginAsynchronous::OTRS::ConcurrentUsers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# 6.5.2 ????-??-??
+ - 2023-04-25 Allow to disable executing Kernel::System::SupportDataCollector::PluginAsynchronous::OTRS::ConcurrentUsers.
+
 # 6.5.1 2023-03-09
  - 2023-02-28 Added options tickets-created-before-date and tickets-created-before-days to console command Admin::Article::StorageSwitch.
  - 2023-02-28 Fixed encoding of postmaster filter name in AdminPostMasterFilter.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,3 @@
-# 6.5.2 ????-??-??
- - 2023-04-25 Allow to disable executing Kernel::System::SupportDataCollector::PluginAsynchronous::OTRS::ConcurrentUsers.
-
 # 6.5.1 2023-03-09
  - 2023-02-28 Added options tickets-created-before-date and tickets-created-before-days to console command Admin::Article::StorageSwitch.
  - 2023-02-28 Fixed encoding of postmaster filter name in AdminPostMasterFilter.

--- a/Kernel/System/Web/InterfaceAgent.pm
+++ b/Kernel/System/Web/InterfaceAgent.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -378,22 +379,26 @@ sub Run {
             return;
         }
 
-        # execution in 20 seconds
-        my $ExecutionTimeObj = $DateTimeObj->Clone();
-        $ExecutionTimeObj->Add( Seconds => 20 );
-        my $ExecutionTime = $ExecutionTimeObj->ToString();
+        # Add a asynchronous executor scheduler task to count the concurrent user if enabled.
+        my $PluginDisabled       = $Kernel::OM->Get('Kernel::Config')->Get('SupportDataCollector::DisablePlugins') || [];
+        my %LookupPluginDisabled = map { $_ => 1 } @{$PluginDisabled};
+        if ( !$LookupPluginDisabled{'Kernel::System::SupportDataCollector::PluginAsynchronous::OTRS::ConcurrentUsers'} ) {
 
-        # add a asychronous executor scheduler task to count the concurrent user
-        $Kernel::OM->Get('Kernel::System::Scheduler')->TaskAdd(
-            ExecutionTime            => $ExecutionTime,
-            Type                     => 'AsynchronousExecutor',
-            Name                     => 'PluginAsynchronous::ConcurrentUser',
-            MaximumParallelInstances => 1,
-            Data                     => {
-                Object   => 'Kernel::System::SupportDataCollector::PluginAsynchronous::OTRS::ConcurrentUsers',
-                Function => 'RunAsynchronous',
-            },
-        );
+            # execution in 20 seconds
+            my $ExecutionTimeObj = $Kernel::OM->Create('Kernel::System::DateTime');
+            $ExecutionTimeObj->Add( Seconds => 20 );
+
+            $Kernel::OM->Get('Kernel::System::Scheduler')->TaskAdd(
+                ExecutionTime            => $ExecutionTimeObj->ToString(),
+                Type                     => 'AsynchronousExecutor',
+                Name                     => 'PluginAsynchronous::ConcurrentUser',
+                MaximumParallelInstances => 1,
+                Data                     => {
+                    Object   => 'Kernel::System::SupportDataCollector::PluginAsynchronous::OTRS::ConcurrentUsers',
+                    Function => 'RunAsynchronous',
+                },
+            );
+        }
 
         my $UserTimeZone = $Self->_UserTimeZoneGet(%UserData);
 

--- a/Kernel/System/Web/InterfaceAgent.pm
+++ b/Kernel/System/Web/InterfaceAgent.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/System/Web/InterfaceAgent.pm
+++ b/Kernel/System/Web/InterfaceAgent.pm
@@ -380,9 +380,10 @@ sub Run {
         }
 
         # Add a asynchronous executor scheduler task to count the concurrent user if enabled.
-        my $PluginDisabled       = $Kernel::OM->Get('Kernel::Config')->Get('SupportDataCollector::DisablePlugins') || [];
+        my $PluginDisabled = $Kernel::OM->Get('Kernel::Config')->Get('SupportDataCollector::DisablePlugins') || [];
         my %LookupPluginDisabled = map { $_ => 1 } @{$PluginDisabled};
-        if ( !$LookupPluginDisabled{'Kernel::System::SupportDataCollector::PluginAsynchronous::OTRS::ConcurrentUsers'} ) {
+        if ( !$LookupPluginDisabled{'Kernel::System::SupportDataCollector::PluginAsynchronous::OTRS::ConcurrentUsers'} )
+        {
 
             # execution in 20 seconds
             my $ExecutionTimeObj = $Kernel::OM->Create('Kernel::System::DateTime');

--- a/Kernel/System/Web/InterfaceCustomer.pm
+++ b/Kernel/System/Web/InterfaceCustomer.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/System/Web/InterfaceCustomer.pm
+++ b/Kernel/System/Web/InterfaceCustomer.pm
@@ -383,9 +383,10 @@ sub Run {
         }
 
         # Add a asynchronous executor scheduler task to count the concurrent user if enabled.
-        my $PluginDisabled       = $Kernel::OM->Get('Kernel::Config')->Get('SupportDataCollector::DisablePlugins') || [];
+        my $PluginDisabled = $Kernel::OM->Get('Kernel::Config')->Get('SupportDataCollector::DisablePlugins') || [];
         my %LookupPluginDisabled = map { $_ => 1 } @{$PluginDisabled};
-        if ( !$LookupPluginDisabled{'Kernel::System::SupportDataCollector::PluginAsynchronous::OTRS::ConcurrentUsers'} ) {
+        if ( !$LookupPluginDisabled{'Kernel::System::SupportDataCollector::PluginAsynchronous::OTRS::ConcurrentUsers'} )
+        {
 
             # execution in 20 seconds
             my $ExecutionTimeObj = $Kernel::OM->Create('Kernel::System::DateTime');


### PR DESCRIPTION
## Proposed change

Znuny executes task Kernel::System::SupportDataCollector::PluginAsynchronous::OTRS::ConcurrentUsers on every user login. This mod allows to disable running it using parameter SupportDataCollector::DisablePlugins i.e. by putting

```
$Self->{'SupportDataCollector::DisablePlugins'} = [ 'Kernel::System::SupportDataCollector::PluginAsynchronous::OTRS::ConcurrentUsers' ];
```

in Config.pm.

## Type of change

- '1 - 🚀 feature'           - New feature (which adds functionality to an existing integration)

## Additional information

Author-Change-Id: IB#1108667

## Checklist
- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [x] Local ZnunyCodePolicy passed.(❕)
- [x] Local UnitTests / Selenium passed.(❕)
- [ ] GitHub workflow CI (UnitTests / Selenium) passed.(❗)
