### PR TITLE
Notification templates initialization fix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,3 @@
-# 6.5.2 ????-??-??
- - 2023-04-25 Ticket email delivery failure notification template initialization fix.
-
 # 6.5.1 2023-03-09
  - 2023-02-28 Added options tickets-created-before-date and tickets-created-before-days to console command Admin::Article::StorageSwitch.
  - 2023-02-28 Fixed encoding of postmaster filter name in AdminPostMasterFilter.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# 6.5.2 ????-??-??
+ - 2023-04-25 Ticket email delivery failure notification template initialization fix.
+
 # 6.5.1 2023-03-09
  - 2023-02-28 Added options tickets-created-before-date and tickets-created-before-days to console command Admin::Article::StorageSwitch.
  - 2023-02-28 Fixed encoding of postmaster filter name in AdminPostMasterFilter.

--- a/scripts/database/initial_insert.mysql.sql
+++ b/scripts/database/initial_insert.mysql.sql
@@ -1634,12 +1634,6 @@ INSERT INTO notification_event_item (notification_id, event_key, event_value)
 # ----------------------------------------------------------
 INSERT INTO notification_event_item (notification_id, event_key, event_value)
     VALUES
-    (15, 'TransportEmailTemplate', 'Default');
-# ----------------------------------------------------------
-#  insert into table notification_event_item
-# ----------------------------------------------------------
-INSERT INTO notification_event_item (notification_id, event_key, event_value)
-    VALUES
     (15, 'Transports', 'Email');
 # ----------------------------------------------------------
 #  insert into table notification_event_item
@@ -1677,12 +1671,6 @@ INSERT INTO notification_event_item (notification_id, event_key, event_value)
 INSERT INTO notification_event_item (notification_id, event_key, event_value)
     VALUES
     (16, 'LanguageID', 'en');
-# ----------------------------------------------------------
-#  insert into table notification_event_item
-# ----------------------------------------------------------
-INSERT INTO notification_event_item (notification_id, event_key, event_value)
-    VALUES
-    (16, 'TransportEmailTemplate', 'Default');
 # ----------------------------------------------------------
 #  insert into table notification_event_item
 # ----------------------------------------------------------

--- a/scripts/database/initial_insert.oracle.sql
+++ b/scripts/database/initial_insert.oracle.sql
@@ -1636,12 +1636,6 @@ INSERT INTO notification_event_item (notification_id, event_key, event_value)
 -- ----------------------------------------------------------
 INSERT INTO notification_event_item (notification_id, event_key, event_value)
     VALUES
-    (15, 'TransportEmailTemplate', 'Default');
--- ----------------------------------------------------------
---  insert into table notification_event_item
--- ----------------------------------------------------------
-INSERT INTO notification_event_item (notification_id, event_key, event_value)
-    VALUES
     (15, 'Transports', 'Email');
 -- ----------------------------------------------------------
 --  insert into table notification_event_item
@@ -1679,12 +1673,6 @@ INSERT INTO notification_event_item (notification_id, event_key, event_value)
 INSERT INTO notification_event_item (notification_id, event_key, event_value)
     VALUES
     (16, 'LanguageID', 'en');
--- ----------------------------------------------------------
---  insert into table notification_event_item
--- ----------------------------------------------------------
-INSERT INTO notification_event_item (notification_id, event_key, event_value)
-    VALUES
-    (16, 'TransportEmailTemplate', 'Default');
 -- ----------------------------------------------------------
 --  insert into table notification_event_item
 -- ----------------------------------------------------------

--- a/scripts/database/initial_insert.postgresql.sql
+++ b/scripts/database/initial_insert.postgresql.sql
@@ -1635,12 +1635,6 @@ INSERT INTO notification_event_item (notification_id, event_key, event_value)
 -- ----------------------------------------------------------
 INSERT INTO notification_event_item (notification_id, event_key, event_value)
     VALUES
-    (15, 'TransportEmailTemplate', 'Default');
--- ----------------------------------------------------------
---  insert into table notification_event_item
--- ----------------------------------------------------------
-INSERT INTO notification_event_item (notification_id, event_key, event_value)
-    VALUES
     (15, 'Transports', 'Email');
 -- ----------------------------------------------------------
 --  insert into table notification_event_item
@@ -1678,12 +1672,6 @@ INSERT INTO notification_event_item (notification_id, event_key, event_value)
 INSERT INTO notification_event_item (notification_id, event_key, event_value)
     VALUES
     (16, 'LanguageID', 'en');
--- ----------------------------------------------------------
---  insert into table notification_event_item
--- ----------------------------------------------------------
-INSERT INTO notification_event_item (notification_id, event_key, event_value)
-    VALUES
-    (16, 'TransportEmailTemplate', 'Default');
 -- ----------------------------------------------------------
 --  insert into table notification_event_item
 -- ----------------------------------------------------------

--- a/scripts/database/initial_insert.xml
+++ b/scripts/database/initial_insert.xml
@@ -2142,11 +2142,6 @@ Your Znuny Team
     </Insert>
     <Insert Table="notification_event_item">
         <Data Key="notification_id">15</Data>
-        <Data Key="event_key" Type="Quote">TransportEmailTemplate</Data>
-        <Data Key="event_value" Type="Quote">Default</Data>
-    </Insert>
-    <Insert Table="notification_event_item">
-        <Data Key="notification_id">15</Data>
         <Data Key="event_key" Type="Quote">Transports</Data>
         <Data Key="event_value" Type="Quote">Email</Data>
     </Insert>
@@ -2185,11 +2180,6 @@ Your Znuny Team
         <Data Key="notification_id">16</Data>
         <Data Key="event_key" Type="Quote">LanguageID</Data>
         <Data Key="event_value" Type="Quote">en</Data>
-    </Insert>
-    <Insert Table="notification_event_item">
-        <Data Key="notification_id">16</Data>
-        <Data Key="event_key" Type="Quote">TransportEmailTemplate</Data>
-        <Data Key="event_value" Type="Quote">Default</Data>
     </Insert>
     <Insert Table="notification_event_item">
         <Data Key="notification_id">16</Data>


### PR DESCRIPTION
## Proposed change

Two youngest notifications ID 15 and ID 16 were introduced with e-mail template set to `Default` which is inconsistent with other e-mail notification templates in system. This mod fixes it (both notifications will initialize template same way as other notifications).

## Type of change
- '1 - 🐞 bug 🐞'            - Bugfix (non-breaking change which fixes an issue)

## Additional information

Replaces: https://github.com/znuny/Znuny/pull/100
Author-Change-Id: IB#1109073

## Checklist
- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [x] Local ZnunyCodePolicy passed.(❕)
- [x] Local UnitTests / Selenium passed.(❕)
- [ ] GitHub workflow CI (UnitTests / Selenium) passed.(❗)
