### PR TITLE
Added option to run daemon without detaching

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,3 @@
-# 6.5.2 ????-??-??
- - 2023-04-26 Added option to run daemon without detaching.
-
 # 6.5.1 2023-03-09
  - 2023-02-28 Added options tickets-created-before-date and tickets-created-before-days to console command Admin::Article::StorageSwitch.
  - 2023-02-28 Fixed encoding of postmaster filter name in AdminPostMasterFilter.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# 6.5.2 ????-??-??
+ - 2023-04-26 Added option to run daemon without detaching.
+
 # 6.5.1 2023-03-09
  - 2023-02-28 Added options tickets-created-before-date and tickets-created-before-days to console command Admin::Article::StorageSwitch.
  - 2023-02-28 Fixed encoding of postmaster filter name in AdminPostMasterFilter.

--- a/bin/otrs.Daemon.pl
+++ b/bin/otrs.Daemon.pl
@@ -2,7 +2,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/bin/otrs.Daemon.pl
+++ b/bin/otrs.Daemon.pl
@@ -109,8 +109,7 @@ my %DebugDaemons;
 my $Debug;
 my $Foreground;
 
-
-if ( # Check for foreground mode.
+if (    # Check for foreground mode.
     lc $ARGV[0] eq 'start'
     && $ARGV[1]
     && lc $ARGV[1] eq '--foreground'
@@ -118,7 +117,7 @@ if ( # Check for foreground mode.
 {
     $Foreground = 1;
 }
-elsif ( # Check for debug mode.
+elsif (    # Check for debug mode.
     lc $ARGV[0] eq 'start'
     && $ARGV[1]
     && lc $ARGV[1] eq '--debug'
@@ -188,10 +187,10 @@ sub PrintUsage {
         'Reduce the time the main daemon waits other daemons to stop.' . "\n";
     $UsageText .= sprintf " %-22s - %s", '[--foreground]', 'Run the daemon in foreground.' . "\n";
     $UsageText .= "\nActions:\n";
-    $UsageText .= sprintf " %-22s - %s", 'start', 'Start the daemon process.' . "\n";
-    $UsageText .= sprintf " %-22s - %s", 'stop', 'Stop the daemon process.' . "\n";
-    $UsageText .= sprintf " %-22s - %s", 'status', 'Show daemon process current state.' . "\n";
-    $UsageText .= sprintf " %-22s - %s", 'help', 'Display help for this command.' . "\n";
+    $UsageText .= sprintf " %-22s - %s", 'start',          'Start the daemon process.' . "\n";
+    $UsageText .= sprintf " %-22s - %s", 'stop',           'Stop the daemon process.' . "\n";
+    $UsageText .= sprintf " %-22s - %s", 'status',         'Show daemon process current state.' . "\n";
+    $UsageText .= sprintf " %-22s - %s", 'help',           'Display help for this command.' . "\n";
     $UsageText .= "\nHelp:\n";
     $UsageText
         .= "In debug mode if a daemon module is specified the debug mode will be activated only for that daemon.\n";
@@ -208,7 +207,7 @@ sub PrintUsage {
 sub Start {
 
     # Detach daemon if should not be run in foreground.
-    if (!$Foreground) {
+    if ( !$Foreground ) {
 
         # Create a fork of the current process.
         #   Parent gets the PID of the child.


### PR DESCRIPTION
## Proposed change

This mod adds parameter --foreground to otrs.Daemon.pl to allow
running it without detaching.

Example `/etc/systemd/system/unit.otrs-daemon.service` unit file
to supervise otrs daemon with systemd instead of cron:

```
[Unit]
Description=OTRS daemon
Wants=cron.service apache2.service mariadb.service postfix.service rsyslog.service
After=cron.service apache2.service mariadb.service postfix.service rsyslog.service

[Service]
ExecStart=/opt/otrs/bin/otrs.Daemon.pl start --foreground
ExecStop=/opt/otrs/bin/otrs.Daemon.pl stop
User=otrs
Restart=on-abort
RestartSec=30

[Install]
WantedBy=multi-user.target
```

## Type of change
- '1 - 🚀 feature'           - New feature (which adds functionality to an existing integration)

## Additional information

Author-Change-Id: IB#1109757

## Checklist
- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [x] Local ZnunyCodePolicy passed.(❕)
- [x] Local UnitTests / Selenium passed.(❕)
- [ ] GitHub workflow CI (UnitTests / Selenium) passed.(❗)
