### PR TITLE
Allow up to 30 Daemon::SchedulerCronTaskManager::Task###CustomX parameters

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# 6.5.2 ????-??-??
+ - 2023-04-26 Allow up to 30 Daemon::SchedulerCronTaskManager::Task###CustomX settings.
+
 # 6.5.1 2023-03-09
  - 2023-02-28 Added options tickets-created-before-date and tickets-created-before-days to console command Admin::Article::StorageSwitch.
  - 2023-02-28 Fixed encoding of postmaster filter name in AdminPostMasterFilter.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,3 @@
-# 6.5.2 ????-??-??
- - 2023-04-26 Allow up to 30 Daemon::SchedulerCronTaskManager::Task###CustomX settings.
-
 # 6.5.1 2023-03-09
  - 2023-02-28 Added options tickets-created-before-date and tickets-created-before-days to console command Admin::Article::StorageSwitch.
  - 2023-02-28 Fixed encoding of postmaster filter name in AdminPostMasterFilter.

--- a/Kernel/Config/Files/XML/Daemon.xml
+++ b/Kernel/Config/Files/XML/Daemon.xml
@@ -619,6 +619,363 @@
             </Hash>
         </Value>
     </Setting>
+    <Setting Name="Daemon::SchedulerCronTaskManager::Task###Custom10" Required="0" Valid="0" ConfigLevel="100">
+        <Description Translatable="1">Executes a custom command or module. Note: if module is used, function is required.</Description>
+        <Navigation>Daemon::SchedulerCronTaskManager::Task</Navigation>
+        <Value>
+            <Hash>
+                <Item Key="TaskName">Custom10</Item>
+                <Item Key="Schedule">* * * * *</Item>
+                <Item Key="Module"></Item>
+                <Item Key="Function"></Item>
+                <Item Key="MaximumParallelInstances">1</Item>
+                <Item Key="Params">
+                    <Array>
+                    </Array>
+                </Item>
+            </Hash>
+        </Value>
+    </Setting>
+    <Setting Name="Daemon::SchedulerCronTaskManager::Task###Custom11" Required="0" Valid="0" ConfigLevel="100">
+        <Description Translatable="1">Executes a custom command or module. Note: if module is used, function is required.</Description>
+        <Navigation>Daemon::SchedulerCronTaskManager::Task</Navigation>
+        <Value>
+            <Hash>
+                <Item Key="TaskName">Custom11</Item>
+                <Item Key="Schedule">* * * * *</Item>
+                <Item Key="Module"></Item>
+                <Item Key="Function"></Item>
+                <Item Key="MaximumParallelInstances">1</Item>
+                <Item Key="Params">
+                    <Array>
+                    </Array>
+                </Item>
+            </Hash>
+        </Value>
+    </Setting>
+    <Setting Name="Daemon::SchedulerCronTaskManager::Task###Custom12" Required="0" Valid="0" ConfigLevel="100">
+        <Description Translatable="1">Executes a custom command or module. Note: if module is used, function is required.</Description>
+        <Navigation>Daemon::SchedulerCronTaskManager::Task</Navigation>
+        <Value>
+            <Hash>
+                <Item Key="TaskName">Custom12</Item>
+                <Item Key="Schedule">* * * * *</Item>
+                <Item Key="Module"></Item>
+                <Item Key="Function"></Item>
+                <Item Key="MaximumParallelInstances">1</Item>
+                <Item Key="Params">
+                    <Array>
+                    </Array>
+                </Item>
+            </Hash>
+        </Value>
+    </Setting>
+    <Setting Name="Daemon::SchedulerCronTaskManager::Task###Custom13" Required="0" Valid="0" ConfigLevel="100">
+        <Description Translatable="1">Executes a custom command or module. Note: if module is used, function is required.</Description>
+        <Navigation>Daemon::SchedulerCronTaskManager::Task</Navigation>
+        <Value>
+            <Hash>
+                <Item Key="TaskName">Custom13</Item>
+                <Item Key="Schedule">* * * * *</Item>
+                <Item Key="Module"></Item>
+                <Item Key="Function"></Item>
+                <Item Key="MaximumParallelInstances">1</Item>
+                <Item Key="Params">
+                    <Array>
+                    </Array>
+                </Item>
+            </Hash>
+        </Value>
+    </Setting>
+    <Setting Name="Daemon::SchedulerCronTaskManager::Task###Custom14" Required="0" Valid="0" ConfigLevel="100">
+        <Description Translatable="1">Executes a custom command or module. Note: if module is used, function is required.</Description>
+        <Navigation>Daemon::SchedulerCronTaskManager::Task</Navigation>
+        <Value>
+            <Hash>
+                <Item Key="TaskName">Custom14</Item>
+                <Item Key="Schedule">* * * * *</Item>
+                <Item Key="Module"></Item>
+                <Item Key="Function"></Item>
+                <Item Key="MaximumParallelInstances">1</Item>
+                <Item Key="Params">
+                    <Array>
+                    </Array>
+                </Item>
+            </Hash>
+        </Value>
+    </Setting>
+    <Setting Name="Daemon::SchedulerCronTaskManager::Task###Custom15" Required="0" Valid="0" ConfigLevel="100">
+        <Description Translatable="1">Executes a custom command or module. Note: if module is used, function is required.</Description>
+        <Navigation>Daemon::SchedulerCronTaskManager::Task</Navigation>
+        <Value>
+            <Hash>
+                <Item Key="TaskName">Custom15</Item>
+                <Item Key="Schedule">* * * * *</Item>
+                <Item Key="Module"></Item>
+                <Item Key="Function"></Item>
+                <Item Key="MaximumParallelInstances">1</Item>
+                <Item Key="Params">
+                    <Array>
+                    </Array>
+                </Item>
+            </Hash>
+        </Value>
+    </Setting>
+    <Setting Name="Daemon::SchedulerCronTaskManager::Task###Custom16" Required="0" Valid="0" ConfigLevel="100">
+        <Description Translatable="1">Executes a custom command or module. Note: if module is used, function is required.</Description>
+        <Navigation>Daemon::SchedulerCronTaskManager::Task</Navigation>
+        <Value>
+            <Hash>
+                <Item Key="TaskName">Custom16</Item>
+                <Item Key="Schedule">* * * * *</Item>
+                <Item Key="Module"></Item>
+                <Item Key="Function"></Item>
+                <Item Key="MaximumParallelInstances">1</Item>
+                <Item Key="Params">
+                    <Array>
+                    </Array>
+                </Item>
+            </Hash>
+        </Value>
+    </Setting>
+    <Setting Name="Daemon::SchedulerCronTaskManager::Task###Custom17" Required="0" Valid="0" ConfigLevel="100">
+        <Description Translatable="1">Executes a custom command or module. Note: if module is used, function is required.</Description>
+        <Navigation>Daemon::SchedulerCronTaskManager::Task</Navigation>
+        <Value>
+            <Hash>
+                <Item Key="TaskName">Custom17</Item>
+                <Item Key="Schedule">* * * * *</Item>
+                <Item Key="Module"></Item>
+                <Item Key="Function"></Item>
+                <Item Key="MaximumParallelInstances">1</Item>
+                <Item Key="Params">
+                    <Array>
+                    </Array>
+                </Item>
+            </Hash>
+        </Value>
+    </Setting>
+    <Setting Name="Daemon::SchedulerCronTaskManager::Task###Custom18" Required="0" Valid="0" ConfigLevel="100">
+        <Description Translatable="1">Executes a custom command or module. Note: if module is used, function is required.</Description>
+        <Navigation>Daemon::SchedulerCronTaskManager::Task</Navigation>
+        <Value>
+            <Hash>
+                <Item Key="TaskName">Custom18</Item>
+                <Item Key="Schedule">* * * * *</Item>
+                <Item Key="Module"></Item>
+                <Item Key="Function"></Item>
+                <Item Key="MaximumParallelInstances">1</Item>
+                <Item Key="Params">
+                    <Array>
+                    </Array>
+                </Item>
+            </Hash>
+        </Value>
+    </Setting>
+    <Setting Name="Daemon::SchedulerCronTaskManager::Task###Custom19" Required="0" Valid="0" ConfigLevel="100">
+        <Description Translatable="1">Executes a custom command or module. Note: if module is used, function is required.</Description>
+        <Navigation>Daemon::SchedulerCronTaskManager::Task</Navigation>
+        <Value>
+            <Hash>
+                <Item Key="TaskName">Custom19</Item>
+                <Item Key="Schedule">* * * * *</Item>
+                <Item Key="Module"></Item>
+                <Item Key="Function"></Item>
+                <Item Key="MaximumParallelInstances">1</Item>
+                <Item Key="Params">
+                    <Array>
+                    </Array>
+                </Item>
+            </Hash>
+        </Value>
+    </Setting>
+    <Setting Name="Daemon::SchedulerCronTaskManager::Task###Custom20" Required="0" Valid="0" ConfigLevel="100">
+        <Description Translatable="1">Executes a custom command or module. Note: if module is used, function is required.</Description>
+        <Navigation>Daemon::SchedulerCronTaskManager::Task</Navigation>
+        <Value>
+            <Hash>
+                <Item Key="TaskName">Custom20</Item>
+                <Item Key="Schedule">* * * * *</Item>
+                <Item Key="Module"></Item>
+                <Item Key="Function"></Item>
+                <Item Key="MaximumParallelInstances">1</Item>
+                <Item Key="Params">
+                    <Array>
+                    </Array>
+                </Item>
+            </Hash>
+        </Value>
+    </Setting>
+    <Setting Name="Daemon::SchedulerCronTaskManager::Task###Custom21" Required="0" Valid="0" ConfigLevel="100">
+        <Description Translatable="1">Executes a custom command or module. Note: if module is used, function is required.</Description>
+        <Navigation>Daemon::SchedulerCronTaskManager::Task</Navigation>
+        <Value>
+            <Hash>
+                <Item Key="TaskName">Custom21</Item>
+                <Item Key="Schedule">* * * * *</Item>
+                <Item Key="Module"></Item>
+                <Item Key="Function"></Item>
+                <Item Key="MaximumParallelInstances">1</Item>
+                <Item Key="Params">
+                    <Array>
+                    </Array>
+                </Item>
+            </Hash>
+        </Value>
+    </Setting>
+    <Setting Name="Daemon::SchedulerCronTaskManager::Task###Custom22" Required="0" Valid="0" ConfigLevel="100">
+        <Description Translatable="1">Executes a custom command or module. Note: if module is used, function is required.</Description>
+        <Navigation>Daemon::SchedulerCronTaskManager::Task</Navigation>
+        <Value>
+            <Hash>
+                <Item Key="TaskName">Custom22</Item>
+                <Item Key="Schedule">* * * * *</Item>
+                <Item Key="Module"></Item>
+                <Item Key="Function"></Item>
+                <Item Key="MaximumParallelInstances">1</Item>
+                <Item Key="Params">
+                    <Array>
+                    </Array>
+                </Item>
+            </Hash>
+        </Value>
+    </Setting>
+    <Setting Name="Daemon::SchedulerCronTaskManager::Task###Custom23" Required="0" Valid="0" ConfigLevel="100">
+        <Description Translatable="1">Executes a custom command or module. Note: if module is used, function is required.</Description>
+        <Navigation>Daemon::SchedulerCronTaskManager::Task</Navigation>
+        <Value>
+            <Hash>
+                <Item Key="TaskName">Custom23</Item>
+                <Item Key="Schedule">* * * * *</Item>
+                <Item Key="Module"></Item>
+                <Item Key="Function"></Item>
+                <Item Key="MaximumParallelInstances">1</Item>
+                <Item Key="Params">
+                    <Array>
+                    </Array>
+                </Item>
+            </Hash>
+        </Value>
+    </Setting>
+    <Setting Name="Daemon::SchedulerCronTaskManager::Task###Custom24" Required="0" Valid="0" ConfigLevel="100">
+        <Description Translatable="1">Executes a custom command or module. Note: if module is used, function is required.</Description>
+        <Navigation>Daemon::SchedulerCronTaskManager::Task</Navigation>
+        <Value>
+            <Hash>
+                <Item Key="TaskName">Custom24</Item>
+                <Item Key="Schedule">* * * * *</Item>
+                <Item Key="Module"></Item>
+                <Item Key="Function"></Item>
+                <Item Key="MaximumParallelInstances">1</Item>
+                <Item Key="Params">
+                    <Array>
+                    </Array>
+                </Item>
+            </Hash>
+        </Value>
+    </Setting>
+    <Setting Name="Daemon::SchedulerCronTaskManager::Task###Custom25" Required="0" Valid="0" ConfigLevel="100">
+        <Description Translatable="1">Executes a custom command or module. Note: if module is used, function is required.</Description>
+        <Navigation>Daemon::SchedulerCronTaskManager::Task</Navigation>
+        <Value>
+            <Hash>
+                <Item Key="TaskName">Custom25</Item>
+                <Item Key="Schedule">* * * * *</Item>
+                <Item Key="Module"></Item>
+                <Item Key="Function"></Item>
+                <Item Key="MaximumParallelInstances">1</Item>
+                <Item Key="Params">
+                    <Array>
+                    </Array>
+                </Item>
+            </Hash>
+        </Value>
+    </Setting>
+    <Setting Name="Daemon::SchedulerCronTaskManager::Task###Custom26" Required="0" Valid="0" ConfigLevel="100">
+        <Description Translatable="1">Executes a custom command or module. Note: if module is used, function is required.</Description>
+        <Navigation>Daemon::SchedulerCronTaskManager::Task</Navigation>
+        <Value>
+            <Hash>
+                <Item Key="TaskName">Custom26</Item>
+                <Item Key="Schedule">* * * * *</Item>
+                <Item Key="Module"></Item>
+                <Item Key="Function"></Item>
+                <Item Key="MaximumParallelInstances">1</Item>
+                <Item Key="Params">
+                    <Array>
+                    </Array>
+                </Item>
+            </Hash>
+        </Value>
+    </Setting>
+    <Setting Name="Daemon::SchedulerCronTaskManager::Task###Custom27" Required="0" Valid="0" ConfigLevel="100">
+        <Description Translatable="1">Executes a custom command or module. Note: if module is used, function is required.</Description>
+        <Navigation>Daemon::SchedulerCronTaskManager::Task</Navigation>
+        <Value>
+            <Hash>
+                <Item Key="TaskName">Custom27</Item>
+                <Item Key="Schedule">* * * * *</Item>
+                <Item Key="Module"></Item>
+                <Item Key="Function"></Item>
+                <Item Key="MaximumParallelInstances">1</Item>
+                <Item Key="Params">
+                    <Array>
+                    </Array>
+                </Item>
+            </Hash>
+        </Value>
+    </Setting>
+    <Setting Name="Daemon::SchedulerCronTaskManager::Task###Custom28" Required="0" Valid="0" ConfigLevel="100">
+        <Description Translatable="1">Executes a custom command or module. Note: if module is used, function is required.</Description>
+        <Navigation>Daemon::SchedulerCronTaskManager::Task</Navigation>
+        <Value>
+            <Hash>
+                <Item Key="TaskName">Custom28</Item>
+                <Item Key="Schedule">* * * * *</Item>
+                <Item Key="Module"></Item>
+                <Item Key="Function"></Item>
+                <Item Key="MaximumParallelInstances">1</Item>
+                <Item Key="Params">
+                    <Array>
+                    </Array>
+                </Item>
+            </Hash>
+        </Value>
+    </Setting>
+    <Setting Name="Daemon::SchedulerCronTaskManager::Task###Custom29" Required="0" Valid="0" ConfigLevel="100">
+        <Description Translatable="1">Executes a custom command or module. Note: if module is used, function is required.</Description>
+        <Navigation>Daemon::SchedulerCronTaskManager::Task</Navigation>
+        <Value>
+            <Hash>
+                <Item Key="TaskName">Custom29</Item>
+                <Item Key="Schedule">* * * * *</Item>
+                <Item Key="Module"></Item>
+                <Item Key="Function"></Item>
+                <Item Key="MaximumParallelInstances">1</Item>
+                <Item Key="Params">
+                    <Array>
+                    </Array>
+                </Item>
+            </Hash>
+        </Value>
+    </Setting>
+    <Setting Name="Daemon::SchedulerCronTaskManager::Task###Custom30" Required="0" Valid="0" ConfigLevel="100">
+        <Description Translatable="1">Executes a custom command or module. Note: if module is used, function is required.</Description>
+        <Navigation>Daemon::SchedulerCronTaskManager::Task</Navigation>
+        <Value>
+            <Hash>
+                <Item Key="TaskName">Custom30</Item>
+                <Item Key="Schedule">* * * * *</Item>
+                <Item Key="Module"></Item>
+                <Item Key="Function"></Item>
+                <Item Key="MaximumParallelInstances">1</Item>
+                <Item Key="Params">
+                    <Array>
+                    </Array>
+                </Item>
+            </Hash>
+        </Value>
+    </Setting>
     <!-- custom generic agent tasks -->
     <Setting Name="Daemon::SchedulerCronTaskManager::Task###GenericAgentFile1" Required="0" Valid="0" ConfigLevel="100">
         <Description Translatable="1">Run file based generic agent jobs (Note: module name needs to be specified in -configuration-module param e.g. "Kernel::System::GenericAgent").</Description>


### PR DESCRIPTION
## Proposed change

This mod increases number of Daemon::SchedulerCronTaskManager::Task###CustomX parameters to 30 (was 9).

## Type of change
- '1 - 🚀 feature'           - New feature (which adds functionality to an existing integration)

## Additional information

Author-Change-Id: IB#1109829

## Checklist
- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [x] Local ZnunyCodePolicy passed.(❕)
- [x] Local UnitTests / Selenium passed.(❕)
- [ ] GitHub workflow CI (UnitTests / Selenium) passed.(❗)
