### PR TITLE
Fixed wrong otrs.Daemon.pl exit code after valid termination

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# 6.5.2 ????-??-??
+ - 2023-04-26 Fixed wrong otrs.Daemon.pl exit code after valid termination.
+
 # 6.5.1 2023-03-09
  - 2023-02-28 Added options tickets-created-before-date and tickets-created-before-days to console command Admin::Article::StorageSwitch.
  - 2023-02-28 Fixed encoding of postmaster filter name in AdminPostMasterFilter.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,3 @@
-# 6.5.2 ????-??-??
- - 2023-04-26 Fixed wrong otrs.Daemon.pl exit code after valid termination.
-
 # 6.5.1 2023-03-09
  - 2023-02-28 Added options tickets-created-before-date and tickets-created-before-days to console command Admin::Article::StorageSwitch.
  - 2023-02-28 Fixed encoding of postmaster filter name in AdminPostMasterFilter.

--- a/bin/otrs.Daemon.pl
+++ b/bin/otrs.Daemon.pl
@@ -2,7 +2,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/bin/otrs.Daemon.pl
+++ b/bin/otrs.Daemon.pl
@@ -2,6 +2,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -356,7 +357,7 @@ sub Start {
     # Remove current log files without content.
     _LogFilesCleanup();
 
-    return 0;
+    return 1;
 }
 
 sub Stop {


### PR DESCRIPTION
## Proposed change

When otrs.Daemon.pl daemon process receives INT signal to terminate (i.e. from "otrs.Daemon.pl stop" command) it exits with code 1 not 0 as it should. This mod fixes it.

To reproduce try starting with --foreground option introduced in https://github.com/znuny/Znuny/pull/399 and then stopping daemon and watch daemon process exit code.

## Type of change
- '1 - 🐞 bug 🐞'            - Bugfix (non-breaking change which fixes an issue)

## Additional information

Related: https://github.com/znuny/Znuny/pull/109#issuecomment-910001106
Related: https://github.com/znuny/Znuny/pull/399
Author-Change-Id: IB#1110219

## Checklist
- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [x] Local ZnunyCodePolicy passed.(❕)
- [x] Local UnitTests / Selenium passed.(❕)
- [ ] GitHub workflow CI (UnitTests / Selenium) passed.(❗)
