### PR TITLE
Hide all password fields when backend without db pass is used

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# 6.5.2 ????-??-??
+ - 2023-04-26 All password fields hidden when backend without db pass is used.
+
 # 6.5.1 2023-03-09
  - 2023-02-28 Added options tickets-created-before-date and tickets-created-before-days to console command Admin::Article::StorageSwitch.
  - 2023-02-28 Fixed encoding of postmaster filter name in AdminPostMasterFilter.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,3 @@
-# 6.5.2 ????-??-??
- - 2023-04-26 All password fields hidden when backend without db pass is used.
-
 # 6.5.1 2023-03-09
  - 2023-02-28 Added options tickets-created-before-date and tickets-created-before-days to console command Admin::Article::StorageSwitch.
  - 2023-02-28 Fixed encoding of postmaster filter name in AdminPostMasterFilter.

--- a/Kernel/Modules/AdminCustomerUser.pm
+++ b/Kernel/Modules/AdminCustomerUser.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/Modules/AdminCustomerUser.pm
+++ b/Kernel/Modules/AdminCustomerUser.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -1084,6 +1085,11 @@ sub _Edit {
     if ( $ConfigObject->Get( $Param{Source} )->{ReadOnly} || $ConfigObject->Get( $Param{Source} )->{Module} =~ /LDAP/i )
     {
         $UpdateOnlyPreferences = 1;
+    }
+
+    # Hide password field if backend that does not require password from db it is enabled.
+    if ( $ConfigObject->Get('Customer::AuthModule') =~ /(LDAP|HTTPBasicAuth|Radius)/i ) {
+        $Param{PwHidden} = 1;
     }
 
     # Get dynamic field backend object.

--- a/Kernel/Modules/AdminUser.pm
+++ b/Kernel/Modules/AdminUser.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/Modules/AdminUser.pm
+++ b/Kernel/Modules/AdminUser.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -452,6 +453,11 @@ sub _Edit {
                 },
             );
         }
+    }
+
+    # Hide password field if backend that does not require password from db it is enabled.
+    if ( $Kernel::OM->Get('Kernel::Config')->Get('AuthModule') =~ /(LDAP|HTTPBasicAuth|Radius)/i ) {
+        $Param{PwHidden} = 1;
     }
 
     # get valid list

--- a/Kernel/Output/HTML/Templates/Standard/AdminCustomerUser.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminCustomerUser.tt
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -256,6 +257,7 @@
                         </div>
                         <div class="Clear"></div>
 [% RenderBlockEnd("PreferencesGenericInput") %]
+[% IF !Data.PwHidden %]
 [% RenderBlockStart("PreferencesGenericPassword") %]
                         <label class="[% Data.RequiredLabelClass | html %]" for="[% Data.Name | html %]"><span class="Marker">[% Data.RequiredLabelCharacter | html %]</span> [% Translate(Data.Item) | html %]:</label>
                         <div class="Field">
@@ -265,6 +267,7 @@
                         </div>
                         <div class="Clear"></div>
 [% RenderBlockEnd("PreferencesGenericPassword") %]
+[% END %]
 [% RenderBlockStart("PreferencesGenericOption") %]
                         <label class="[% Data.RequiredLabelClass | html %]" for="[% Data.Name | html %]"><span class="Marker">[% Data.RequiredLabelCharacter | html %]</span> [% Translate(Data.Item) | html %]:</label>
                         <div class="Field">

--- a/Kernel/Output/HTML/Templates/Standard/AdminCustomerUser.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminCustomerUser.tt
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/Output/HTML/Templates/Standard/AdminUser.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminUser.tt
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -237,6 +238,7 @@
                             </div>
                         </div>
                         <div class="Clear"></div>
+[% IF !Data.PwHidden %]
 
                         <label for="UserPw">
                             [% Translate("Password") | html %]:
@@ -250,6 +252,7 @@
 [% RenderBlockEnd("ShowPasswordHint") %]
                         </div>
                         <div class="Clear"></div>
+[% END %]
 
                         <label class="Mandatory" for="UserEmail"><span class="Marker">*</span> [% Translate("Email") | html %]:</label>
                         <div class="Field">

--- a/Kernel/Output/HTML/Templates/Standard/AdminUser.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminUser.tt
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you


### PR DESCRIPTION
## Proposed change

When using auth backend that does not require password from db (i.e.
basic auth) Znuny hides correctly password input in agent and customer
preferences (Kernel/Output/HTML/Preferences/Password.pm) but does not
hide password fields in AdminUser nor AdminCustomerUser screens. This
mod hides password fields on these screens also.

## Type of change
- '1 - 🐞 bug 🐞'            - Bugfix (non-breaking change which fixes an issue)

## Additional information

Author-Change-Id: IB#1110411

## Checklist
- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [x] Local ZnunyCodePolicy passed.(❕)
- [x] Local UnitTests / Selenium passed.(❕)
- [ ] GitHub workflow CI (UnitTests / Selenium) passed.(❗)
