### PR TITLE
Allow all agent sync from ldap to db

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,3 @@
-# 6.5.2 ????-??-??
- - 2023-04-26 Allow all agents sync from ldap to db.
-
 # 6.5.1 2023-03-09
  - 2023-02-28 Added options tickets-created-before-date and tickets-created-before-days to console command Admin::Article::StorageSwitch.
  - 2023-02-28 Fixed encoding of postmaster filter name in AdminPostMasterFilter.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# 6.5.2 ????-??-??
+ - 2023-04-26 Allow all agents sync from ldap to db.
+
 # 6.5.1 2023-03-09
  - 2023-02-28 Added options tickets-created-before-date and tickets-created-before-days to console command Admin::Article::StorageSwitch.
  - 2023-02-28 Fixed encoding of postmaster filter name in AdminPostMasterFilter.

--- a/Kernel/Config/Defaults.pm
+++ b/Kernel/Config/Defaults.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -542,6 +543,10 @@ sub LoadDefaults {
     # this option. e. g. AlwaysFilter => '(mail=*)' or AlwaysFilter => '(objectclass=user)'
     # or if you want to filter with a logical OR-Expression, like AlwaysFilter => '(|(mail=*abc.com)(mail=*xyz.com))'
 #    $Self->{'AuthSyncModule::LDAP::AlwaysFilter'} = '';
+
+    # Set to 1 if AlwaysFilter returns only valid users (deactivated user will
+    # be automatically updated to valid on sync).
+#    $Self->{'AuthSyncModule::LDAP::AlwaysFilterReturnsOnlyValidUsers'} = 1;
 
     # AuthSyncModule::LDAP::UserSyncMap
     # (map if agent should create/synced from LDAP to DB after successful login)

--- a/Kernel/Config/Defaults.pm
+++ b/Kernel/Config/Defaults.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/System/Auth/Sync/LDAP.pm
+++ b/Kernel/System/Auth/Sync/LDAP.pm
@@ -9,6 +9,7 @@
 # --
 
 package Kernel::System::Auth::Sync::LDAP;
+## nofilter(TidyAll::Plugin::OTRS::Perl::PerlCritic)
 
 use strict;
 use warnings;
@@ -953,6 +954,7 @@ sub SyncAll {
     my $Cookie;
     my $ProcessedLDAPEntries = 0;
 
+	PAGE:
     while (1) {
         $Result = $LDAP->search(
             base => $Self->{BaseDN},
@@ -970,6 +972,7 @@ sub SyncAll {
         }
 
         # Process every UID in page.
+		ENTRY:
         while (my $Entry = $Result->pop_entry()) {
 
             # Extract user UID.
@@ -998,8 +1001,8 @@ sub SyncAll {
         }
 
         # LDAP query paging stuff.
-        my ($Response) = $Result->control(LDAP_CONTROL_PAGED) or last;
-        $Cookie = $Response->cookie or last;
+        my ($Response) = $Result->control(LDAP_CONTROL_PAGED) or last PAGE;
+        $Cookie = $Response->cookie() or last PAGE;
         $Page->cookie($Cookie);
     }
 

--- a/Kernel/System/Auth/Sync/LDAP.pm
+++ b/Kernel/System/Auth/Sync/LDAP.pm
@@ -18,7 +18,7 @@ use Net::LDAP;
 use Net::LDAP::Util qw(escape_filter_value);
 use URI;
 use Net::LDAP::Control::Paged;
-use Net::LDAP::Constant qw( LDAP_CONTROL_PAGED );
+use Net::LDAP::Constant qw(LDAP_CONTROL_PAGED);
 
 our @ObjectDependencies = (
     'Kernel::Config',

--- a/Kernel/System/Auth/Sync/LDAP.pm
+++ b/Kernel/System/Auth/Sync/LDAP.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/System/Auth/Sync/LDAP.pm
+++ b/Kernel/System/Auth/Sync/LDAP.pm
@@ -954,7 +954,7 @@ sub SyncAll {
     my $Cookie;
     my $ProcessedLDAPEntries = 0;
 
-	PAGE:
+    PAGE:
     while (1) {
         $Result = $LDAP->search(
             base => $Self->{BaseDN},
@@ -972,7 +972,7 @@ sub SyncAll {
         }
 
         # Process every UID in page.
-		ENTRY:
+        ENTRY:
         while (my $Entry = $Result->pop_entry()) {
 
             # Extract user UID.

--- a/Kernel/System/Auth/Sync/LDAP.pm
+++ b/Kernel/System/Auth/Sync/LDAP.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -15,6 +16,8 @@ use warnings;
 use Net::LDAP;
 use Net::LDAP::Util qw(escape_filter_value);
 use URI;
+use Net::LDAP::Control::Paged;
+use Net::LDAP::Constant qw( LDAP_CONTROL_PAGED );
 
 our @ObjectDependencies = (
     'Kernel::Config',
@@ -22,6 +25,7 @@ our @ObjectDependencies = (
     'Kernel::System::Group',
     'Kernel::System::Log',
     'Kernel::System::User',
+    'Kernel::System::Valid',
 );
 
 sub new {
@@ -78,6 +82,7 @@ sub new {
 
     # ldap filter always used
     $Self->{AlwaysFilter} = $ConfigObject->Get( 'AuthSyncModule::LDAP::AlwaysFilter' . $Param{Count} ) || '';
+    $Self->{AlwaysFilterReturnsOnlyValidUsers} = $ConfigObject->Get( 'AuthSyncModule::LDAP::AlwaysFilterReturnsOnlyValidUsers' . $Param{Count} ) || '';
 
     # Net::LDAP new params
     if ( $ConfigObject->Get( 'AuthSyncModule::LDAP::Params' . $Param{Count} ) ) {
@@ -338,7 +343,7 @@ sub Sync {
             if ( !$UserID ) {
                 $Kernel::OM->Get('Kernel::System::Log')->Log(
                     Priority => 'error',
-                    Message  => "Can't create user '$Param{User}' ($UserDN) in RDBMS!",
+                    Message  => "Can't create user '$Param{User}' in DB from LDAP DN ${UserDN}!",
                 );
 
                 # take down session
@@ -348,7 +353,7 @@ sub Sync {
             else {
                 $Kernel::OM->Get('Kernel::System::Log')->Log(
                     Priority => 'notice',
-                    Message  => "Initial data for '$Param{User}' ($UserDN) created in RDBMS.",
+                    Message  => "Valid user '$Param{User}' created in DB from LDAP DN ${UserDN}.",
                 );
 
                 # sync initial groups
@@ -387,6 +392,11 @@ sub Sync {
         # update user attributes (only if changed)
         elsif (%SyncUser) {
 
+            if ($Self->{AlwaysFilterReturnsOnlyValidUsers}) {
+                # Force updated user to be valid on sync.
+                $SyncUser{ValidID} = 1;
+            }
+
             # get user data
             my %UserData = $UserObject->GetUserData( User => $Param{User} );
 
@@ -404,7 +414,7 @@ sub Sync {
             }
 
             if ($AttributeChange) {
-                $UserObject->UserUpdate(
+                my $Result = $UserObject->UserUpdate(
                     ValidID   => $UserData{ValidID},    # May be not present in %SyncUser and is required by UserUpdate.
                     UserID    => $UserID,
                     UserLogin => $Param{User},
@@ -412,6 +422,23 @@ sub Sync {
                     UserType     => 'User',
                     ChangeUserID => 1,
                 );
+
+                if (!$Result) {
+                    $Kernel::OM->Get('Kernel::System::Log')->Log(
+                        Priority => 'error',
+                        Message  => "Error updating user '$Param{User}' data in DB from LDAP DN ${UserDN}!",
+                    );
+                }
+                else {
+                    my $MessageExt = '';
+                    if ( ($SyncUser{ValidID} // $UserData{ValidID}) != $UserData{ValidID} ) {
+                        $MessageExt = ' (ValidID changed to ' . ($SyncUser{ValidID} // $UserData{ValidID}) . ')';
+                    }
+                    $Kernel::OM->Get('Kernel::System::Log')->Log(
+                        Priority => 'notice',
+                        Message  => "User '$Param{User}' data updated in DB from LDAP DN ${UserDN}${MessageExt}.",
+                    );
+                }
             }
         }
     }
@@ -483,15 +510,15 @@ sub Sync {
                 }
             }
 
-            # log if there is no LDAP entry
+            # Process next group if user does not belong to group.
             if ( !$Valid ) {
-
-                # failed login note
-                $Kernel::OM->Get('Kernel::System::Log')->Log(
-                    Priority => 'notice',
-                    Message  => "User: $Param{User} not in "
-                        . "GroupDN='$GroupDN', Filter='$Filter'! (REMOTE_ADDR: $RemoteAddr).",
-                );
+                if ( $Self->{Debug} > 0 ) {
+                    $Kernel::OM->Get('Kernel::System::Log')->Log(
+                        Priority => 'notice',
+                        Message  => "User: $Param{User} not in "
+                            . "GroupDN='$GroupDN', Filter='$Filter'! (REMOTE_ADDR: $RemoteAddr).",
+                    );
+                }
                 next GROUPDN;
             }
 
@@ -702,15 +729,15 @@ sub Sync {
                 $Valid = $Entry->dn();
             }
 
-            # log if there is no LDAP entry
+            # Process next group if user does not belong to group.
             if ( !$Valid ) {
-
-                # failed login note
-                $Kernel::OM->Get('Kernel::System::Log')->Log(
-                    Priority => 'notice',
-                    Message  => "User: $Param{User} not in "
-                        . "GroupDN='$GroupDN', Filter='$Filter'! (REMOTE_ADDR: $RemoteAddr).",
-                );
+                if ( $Self->{Debug} > 0 ) {
+                    $Kernel::OM->Get('Kernel::System::Log')->Log(
+                        Priority => 'notice',
+                        Message  => "User: $Param{User} not in "
+                            . "GroupDN='$GroupDN', Filter='$Filter'! (REMOTE_ADDR: $RemoteAddr).",
+                    );
+                }
                 next GROUPDN;
             }
 
@@ -845,6 +872,199 @@ sub Sync {
     $LDAP->unbind();
 
     return $Param{User};
+}
+
+=head2 SyncAll()
+
+Sync all users from LDAP to DB (create if not in DB and update it already exists).
+All users in LDAP are found using BaseDN and AlwaysFilter.
+
+    my $Result = $AuthSyncBackend->SyncAll(
+        InvalidateMissing => 0, # Set to 1 to invalidate all valid users in DB that are not found in this backend.
+    );
+
+=cut
+
+sub SyncAll {
+    my ( $Self, %Param ) = @_;
+
+    my $UserObject = $Kernel::OM->Get('Kernel::System::User');
+
+    $Kernel::OM->Get('Kernel::System::Log')->Log(
+        Priority => 'notice',
+        Message => 'Syncing all users from LDAP'
+            . ($Param{InvalidateMissing} ? ' (with missing user invalidation)' : ''),
+    );
+
+    # Find all valid users from DB; users found in LDAP will be removed from this list
+    # during sync and all the remaining users will be invalidated if $Param{InvalidateMissing}
+    # is enabled.
+    my %UsersToBeInvalidatedInDB;
+    if ($Param{InvalidateMissing}) {
+        %UsersToBeInvalidatedInDB = $UserObject->UserSearch(
+            Search => '*',
+            Valid => 1,
+            Limit => 0, # Don't limit results - we need all valid users.
+        );
+
+        # Reverse hash for easy look up (UIDs as keys).
+        %UsersToBeInvalidatedInDB = reverse %UsersToBeInvalidatedInDB;
+
+        $Kernel::OM->Get('Kernel::System::Log')->Log(
+            Priority => 'notice',
+            Message => 'Number of valid users in DB before sync: ' . keys %UsersToBeInvalidatedInDB,
+        );
+    }
+
+    # LDAP connect and bind (with SearchUserDN and SearchUserPw if specified).
+    my $LDAP = Net::LDAP->new( $Self->{Host}, %{ $Self->{Params} } );
+    if ( !$LDAP ) {
+        if ( $Self->{Die} ) {
+            die "Can't connect to $Self->{Host}: $@";
+        }
+
+        $Kernel::OM->Get('Kernel::System::Log')->Log(
+            Priority => 'error',
+            Message => "Can't connect to $Self->{Host}: $@",
+        );
+        return;
+    }
+    my $Result;
+    if ( $Self->{SearchUserDN} && $Self->{SearchUserPw} ) {
+        $Result = $LDAP->bind(
+            dn => $Self->{SearchUserDN},
+            password => $Self->{SearchUserPw}
+        );
+    }
+    else {
+        $Result = $LDAP->bind();
+    }
+    if ( $Result->code() ) {
+        $Kernel::OM->Get('Kernel::System::Log')->Log(
+            Priority => 'error',
+            Message => 'First bind failed! ' . $Result->error(),
+        );
+        return;
+    }
+
+    # Get all users from LDAP in paging mode (every page up to 500 agents).
+
+    my $Page = Net::LDAP::Control::Paged->new(size => 500);
+    my $Cookie;
+    my $ProcessedLDAPEntries = 0;
+
+    while (1) {
+        $Result = $LDAP->search(
+            base => $Self->{BaseDN},
+            filter => $Self->{AlwaysFilter},
+            attrs   => [$Self->{UID}],
+            control => [$Page]
+        );
+
+        if ( $Result->code() ) {
+            $Kernel::OM->Get('Kernel::System::Log')->Log(
+                Priority => 'error',
+                Message => 'Error on LDAP search: ' . $Result->error(),
+            );
+            return;
+        }
+
+        # Process every UID in page.
+        while (my $Entry = $Result->pop_entry()) {
+
+            # Extract user UID.
+            my $UserLogin = $Entry->get_value($Self->{UID});
+            if (!$UserLogin) {
+                $Kernel::OM->Get('Kernel::System::Log')->Log(
+                    Priority => 'error',
+                    Message => 'User login not found in LDAP response',
+                );
+                return;
+            }
+
+            # Synchronize this user from LDAP. Abort job on error.
+            return if !$Self->Sync(User => $UserLogin);
+
+            $ProcessedLDAPEntries++;
+
+            if ($Param{InvalidateMissing}) {
+
+                # Synchronized user is valid user so remove this UID
+                # from list of users to be invalidated if exists.
+                if ($UsersToBeInvalidatedInDB{$UserLogin}) {
+                    delete $UsersToBeInvalidatedInDB{$UserLogin};
+                }
+            }
+        }
+
+        # LDAP query paging stuff.
+        my ($Response) = $Result->control(LDAP_CONTROL_PAGED) or last;
+        $Cookie = $Response->cookie or last;
+        $Page->cookie($Cookie);
+    }
+
+    # Take down LDAP session.
+    $LDAP->unbind();
+
+    $Kernel::OM->Get('Kernel::System::Log')->Log(
+        Priority => 'notice',
+        Message => 'Number of processed valid users from LDAP: ' . $ProcessedLDAPEntries,
+    );
+
+    # Invalidate all users from DB not found in LDAP if $Param{InvalidateMissing} is enabled.
+    if ($Param{InvalidateMissing}) {
+
+        my $InvalidatedUsers = 0;
+
+        my $ValidID = $Kernel::OM->Get('Kernel::System::Valid')->ValidLookup(
+            Valid => 'invalid',
+        );
+
+        USERLOGIN:
+        for my $UserLogin ( keys %UsersToBeInvalidatedInDB ) {
+            my %User = $UserObject->GetUserData(
+                User => $UserLogin,
+                Valid  => 1,
+            );
+            if (!%User) {
+                $Kernel::OM->Get('Kernel::System::Log')->Log(
+                    Priority => 'error',
+                    Message => "Cannot invalidate user ${UserLogin} (not found or invalid in DB)",
+                );
+                return;
+            }
+
+            # Make sure not to accidentially overwrite the password.
+            delete $User{UserPw};
+
+            my $Result = $UserObject->UserUpdate(
+                %User,
+                ValidID => $ValidID,
+                ChangeUserID => 1,
+            );
+            if (!$Result) {
+                $Kernel::OM->Get('Kernel::System::Log')->Log(
+                    Priority => 'error',
+                    Message => "Error invalidating user ${UserLogin}",
+                );
+                return;
+            }
+
+            $Kernel::OM->Get('Kernel::System::Log')->Log(
+                Priority => 'notice',
+                Message => "User ${UserLogin} invalidated in DB (not found in LDAP)",
+            );
+
+            $InvalidatedUsers++;
+        }
+
+        $Kernel::OM->Get('Kernel::System::Log')->Log(
+            Priority => 'notice',
+            Message => 'Number of users invalidated in DB: ' . $InvalidatedUsers,
+        );
+    }
+
+    return 1;
 }
 
 sub _ConvertTo {

--- a/Kernel/System/Console/Command/Admin/User/SyncAll.pm
+++ b/Kernel/System/Console/Command/Admin/User/SyncAll.pm
@@ -1,0 +1,73 @@
+# --
+# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (GPL). If you
+# did not receive this file, see https://www.gnu.org/licenses/gpl-3.0.txt.
+# --
+
+package Kernel::System::Console::Command::Admin::User::SyncAll;
+## nofilter(TidyAll::Plugin::Znuny::Legal::UpdateZnunyCopyright)
+
+use strict;
+use warnings;
+
+use parent qw(Kernel::System::Console::BaseCommand);
+
+our @ObjectDependencies = (
+    'Kernel::Config',
+    'Kernel::System::Main',
+);
+
+sub Configure {
+    my ( $Self, %Param ) = @_;
+
+    $Self->Description('Synchronize all users from specified sync backend.');
+    $Self->AddOption(
+        Name        => 'count',
+        Description => 'Use AuthSyncModule<count> backend to synchronize from (empty <count> will be used if this parameter is not specified).',
+        Required    => 0,
+        HasValue    => 1,
+        ValueRegex  => qr/\d/smx,
+    );
+    $Self->AddOption(
+        Name        => 'invalidate-missing',
+        Description => "Invalidate valid users in DB that are not found in LDAP.",
+        Required    => 0,
+        HasValue    => 0,
+    );
+    return;
+}
+
+sub Run {
+    my ( $Self, %Param ) = @_;
+
+    my $Count = $Self->GetOption('count') // '';
+
+    # Check if specified AuthSyncModule is configured.
+    my $GenericModule = $Kernel::OM->Get('Kernel::Config')->Get("AuthSyncModule${Count}");
+    if ( !$GenericModule ) {
+        $Self->PrintError("User authentication sync module AuthSyncModule${Count} not configured!");
+        return $Self->ExitCodeError();
+    }
+
+    if ( !$Kernel::OM->Get('Kernel::System::Main')->Require($GenericModule) ) {
+        $Self->PrintError("Invalid AuthSyncModule${Count} value (" . $GenericModule . ')!');
+        return $Self->ExitCodeError();
+    }
+
+    my $AuthSyncBackend = $GenericModule->new( %{$Self}, Count => $Count );
+
+    $Self->Print("<yellow>Starting all users synchronization from AuthSyncModule${Count} (" . $GenericModule . ")...</yellow>\n");
+
+    # Do the sync using specified backend.
+    if (!$AuthSyncBackend->SyncAll(InvalidateMissing => $Self->GetOption('invalidate-missing'))) {
+        $Self->PrintError('Sync failed!');
+        return $Self->ExitCodeError();
+    }
+
+    $Self->Print("<green>Done.</green>\n");
+    return $Self->ExitCodeOk();
+}
+
+1;

--- a/Kernel/System/Console/Command/Admin/User/SyncAll.pm
+++ b/Kernel/System/Console/Command/Admin/User/SyncAll.pm
@@ -24,11 +24,12 @@ sub Configure {
 
     $Self->Description('Synchronize all users from specified sync backend.');
     $Self->AddOption(
-        Name        => 'count',
-        Description => 'Use AuthSyncModule<count> backend to synchronize from (empty <count> will be used if this parameter is not specified).',
-        Required    => 0,
-        HasValue    => 1,
-        ValueRegex  => qr/\d/smx,
+        Name => 'count',
+        Description =>
+            'Use AuthSyncModule<count> backend to synchronize from (empty <count> will be used if this parameter is not specified).',
+        Required   => 0,
+        HasValue   => 1,
+        ValueRegex => qr/\d/smx,
     );
     $Self->AddOption(
         Name        => 'invalidate-missing',
@@ -52,16 +53,20 @@ sub Run {
     }
 
     if ( !$Kernel::OM->Get('Kernel::System::Main')->Require($GenericModule) ) {
-        $Self->PrintError("Invalid AuthSyncModule${Count} value (" . $GenericModule . ')!');
+        $Self->PrintError( "Invalid AuthSyncModule${Count} value (" . $GenericModule . ')!' );
         return $Self->ExitCodeError();
     }
 
     my $AuthSyncBackend = $GenericModule->new( %{$Self}, Count => $Count );
 
-    $Self->Print("<yellow>Starting all users synchronization from AuthSyncModule${Count} (" . $GenericModule . ")...</yellow>\n");
+    $Self->Print(
+        "<yellow>Starting all users synchronization from AuthSyncModule${Count} ("
+            . $GenericModule
+            . ")...</yellow>\n"
+    );
 
     # Do the sync using specified backend.
-    if (!$AuthSyncBackend->SyncAll(InvalidateMissing => $Self->GetOption('invalidate-missing'))) {
+    if ( !$AuthSyncBackend->SyncAll( InvalidateMissing => $Self->GetOption('invalidate-missing') ) ) {
         $Self->PrintError('Sync failed!');
         return $Self->ExitCodeError();
     }


### PR DESCRIPTION
## Proposed change
This mod introduces cli command
```
 otrs.Console.pl Admin::User::SyncAll [--count ...] [--invalidate-missing]
```
that allows to synchronize all agents from specified backend.

Specify --count X to synchronize from AuthSyncBackendX configured
in Config.pm (AuthSyncBackend will be used if --count parameter
is not specified).

Adding --invalidate-missing will force all valid users in DB
that are not present in LDAP backend to be invalidated on sync.

This mod introduces also
AuthSyncModule::LDAP::AlwaysFilterReturnsOnlyValidUsers option; when set,
invalid users in DB will be changed to valid when synchronized from LDAP
to DB.

## Type of change

- '1 - 🚀 feature'           - New feature (which adds functionality to an existing integration)

## Additional information

Author-Change-Id: IB#1110475

## Checklist
- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [x] Local ZnunyCodePolicy passed.(❕)
- [x] Local UnitTests / Selenium passed.(❕)
- [ ] GitHub workflow CI (UnitTests / Selenium) passed.(❗)

