### PR TITLE
Fixed generic agent scheduled jobs immediate executions after schedule change

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,3 @@
-# 6.5.2 ????-??-??
- - 2023-04-26 Fixed generic agent scheduled jobs immediate executions after schedule change.
-
 # 6.5.1 2023-03-09
  - 2023-02-28 Added options tickets-created-before-date and tickets-created-before-days to console command Admin::Article::StorageSwitch.
  - 2023-02-28 Fixed encoding of postmaster filter name in AdminPostMasterFilter.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# 6.5.2 ????-??-??
+ - 2023-04-26 Fixed generic agent scheduled jobs immediate executions after schedule change.
+
 # 6.5.1 2023-03-09
  - 2023-02-28 Added options tickets-created-before-date and tickets-created-before-days to console command Admin::Article::StorageSwitch.
  - 2023-02-28 Fixed encoding of postmaster filter name in AdminPostMasterFilter.

--- a/Kernel/System/GenericAgent.pm
+++ b/Kernel/System/GenericAgent.pm
@@ -19,6 +19,7 @@ use Kernel::System::VariableCheck qw(:all);
 our @ObjectDependencies = (
     'Kernel::Config',
     'Kernel::System::Cache',
+    'Kernel::System::Daemon::SchedulerDB',
     'Kernel::System::DateTime',
     'Kernel::System::DB',
     'Kernel::System::DynamicField',
@@ -854,6 +855,10 @@ sub JobDelete {
     $Kernel::OM->Get('Kernel::System::Cache')->CleanUp(
         Type => 'GenericAgent',
     );
+
+    # Remove job record from scheduler DB to avoid job immediate execution if redefined
+    # with different schedule.
+    $Kernel::OM->Get('Kernel::System::Daemon::SchedulerDB')->GenericAgentTaskCleanup();
 
     return 1;
 }


### PR DESCRIPTION
## Proposed change

When generic agent job is scheduled (i.e. execute at 04:00 everyday) and
then schedule is changed 3 min. later (i.e. execute ar 05:00 everyday),
changed job is executed immediately without waiting for new schedule.

This mod fixes it (job will be executed on next future time matching
new schedule).

## Type of change

- '1 - 🐞 bug 🐞'            - Bugfix (non-breaking change which fixes an issue)

## Additional information

Replaces: https://github.com/znuny/Znuny/pull/125
Author-Change-Id: IB#1110525

## Checklist

- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [x] Local ZnunyCodePolicy passed.(❕)
- [x] Local UnitTests / Selenium passed.(❕)
- [ ] GitHub workflow CI (UnitTests / Selenium) passed.(❗)
