### PR TITLE
Empty envelope sender in daemon notifications

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,3 @@
-# 6.5.2 ????-??-??
- - 2023-04-27 Empty envelope sender in daemon notifications.
-
 # 6.5.1 2023-03-09
  - 2023-02-28 Added options tickets-created-before-date and tickets-created-before-days to console command Admin::Article::StorageSwitch.
  - 2023-02-28 Fixed encoding of postmaster filter name in AdminPostMasterFilter.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# 6.5.2 ????-??-??
+ - 2023-04-27 Empty envelope sender in daemon notifications.
+
 # 6.5.1 2023-03-09
  - 2023-02-28 Added options tickets-created-before-date and tickets-created-before-days to console command Admin::Article::StorageSwitch.
  - 2023-02-28 Fixed encoding of postmaster filter name in AdminPostMasterFilter.

--- a/Kernel/System/Daemon/DaemonModules/BaseTaskWorker.pm
+++ b/Kernel/System/Daemon/DaemonModules/BaseTaskWorker.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/System/Daemon/DaemonModules/BaseTaskWorker.pm
+++ b/Kernel/System/Daemon/DaemonModules/BaseTaskWorker.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -68,6 +69,7 @@ sub _HandleError {
             Charset  => 'utf-8',
             MimeType => 'text/plain',
             Body     => $Param{ErrorMessage},
+            Loop     => 1,
         );
 
         return 1 if $Sent->{Success};


### PR DESCRIPTION
## Proposed change

Znuny daemon notifications are sent with nonempty envelope sender;
in case of delivery failures bounces may be unnecessary generated.

No such problem in regular notifications

https://github.com/znuny/Znuny/blob/dev/Kernel/System/Ticket/Event/NotificationEvent/Transport/Email.pm#L186

This mod sets empty envelope sender for daemon notifications also.

## Type of change
- '1 - 🐞 bug 🐞'            - Bugfix (non-breaking change which fixes an issue)

## Additional information

Replaces: https://github.com/znuny/Znuny/pull/161
Related: https://datatracker.ietf.org/doc/html/rfc5321#section-4.1.1.2
Author-Change-Id: IB#1111343

## Checklist
- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [x] Local ZnunyCodePolicy passed.(❕)
- [x] Local UnitTests / Selenium passed.(❕)
- [ ] GitHub workflow CI (UnitTests / Selenium) passed.(❗)
