### PR TITLE
Bad Content-ID formatting handling in DetectAttachment filter fixed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,3 @@
-# 6.5.2 ????-??-??
- - 2023-04-27 Bad Content-ID formatting handling in DetectAttachment filter fixed.
-
 # 6.5.1 2023-03-09
  - 2023-02-28 Added options tickets-created-before-date and tickets-created-before-days to console command Admin::Article::StorageSwitch.
  - 2023-02-28 Fixed encoding of postmaster filter name in AdminPostMasterFilter.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# 6.5.2 ????-??-??
+ - 2023-04-27 Bad Content-ID formatting handling in DetectAttachment filter fixed.
+
 # 6.5.1 2023-03-09
  - 2023-02-28 Added options tickets-created-before-date and tickets-created-before-days to console command Admin::Article::StorageSwitch.
  - 2023-02-28 Fixed encoding of postmaster filter name in AdminPostMasterFilter.

--- a/Kernel/System/PostMaster/Filter/DetectAttachment.pm
+++ b/Kernel/System/PostMaster/Filter/DetectAttachment.pm
@@ -64,12 +64,12 @@ sub Run {
             my ($ImageID) = ( $Attachment->{ContentID} =~ m{^<(.*)>$}ixms );
 
             # Tolerate ContentID without surrounding <>.
-            if (! defined $ImageID) {
+            if ( !defined $ImageID ) {
                 $ImageID = $Attachment->{ContentID};
             }
 
             # Inline image must not have empty ContentID (<>).
-            if (length $ImageID) {
+            if ( length $ImageID ) {
                 if ( grep { $_->{Content} =~ m{<img.*src=.*['|"]cid:\Q$ImageID\E['|"].*>}ixms } @Attachments ) {
                     $AttachmentInline = 1;
                 }

--- a/Kernel/System/PostMaster/Filter/DetectAttachment.pm
+++ b/Kernel/System/PostMaster/Filter/DetectAttachment.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2022-2023 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/System/PostMaster/Filter/DetectAttachment.pm
+++ b/Kernel/System/PostMaster/Filter/DetectAttachment.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2022-2023 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -61,8 +62,17 @@ sub Run {
             )
         {
             my ($ImageID) = ( $Attachment->{ContentID} =~ m{^<(.*)>$}ixms );
-            if ( grep { $_->{Content} =~ m{<img.*src=.*['|"]cid:\Q$ImageID\E['|"].*>}xms } @Attachments ) {
-                $AttachmentInline = 1;
+
+            # Tolerate ContentID without surrounding <>.
+            if (! defined $ImageID) {
+                $ImageID = $Attachment->{ContentID};
+            }
+
+            # Inline image must not have empty ContentID (<>).
+            if (length $ImageID) {
+                if ( grep { $_->{Content} =~ m{<img.*src=.*['|"]cid:\Q$ImageID\E['|"].*>}ixms } @Attachments ) {
+                    $AttachmentInline = 1;
+                }
             }
         }
 

--- a/scripts/test/PostMaster/Attachments.t
+++ b/scripts/test/PostMaster/Attachments.t
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2022 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/scripts/test/PostMaster/Attachments.t
+++ b/scripts/test/PostMaster/Attachments.t
@@ -132,6 +132,12 @@ my $EmailInlineImage = $MainObject->FileRead(
     Result   => 'ARRAY',
 );
 
+# Read email content that contains inline image with bad Content-ID formatting.
+my $EmailInlineImageBadContentIDFormatting = $MainObject->FileRead(
+    Location => $ConfigObject->Get('Home') . '/scripts/test/sample/PostMaster/InlineImage1.box',
+    Result   => 'ARRAY',
+);
+
 # Workaround due used email have not a From value
 unshift @{$EmailAttachment}, 'From: Sender <sender@example.com>';
 
@@ -228,6 +234,34 @@ my @Tests = (
             DynamicField_TicketFreeText2 => undef,
         },
         Email => $EmailInlineImage,
+    },
+    {
+        Name  => '#4 - With Inline Images and bad Content-ID formatting',
+        Match => [
+            {
+                Key   => 'X-OTRS-AttachmentExists',
+                Value => 'yes',
+            },
+            {
+                Key   => 'X-OTRS-AttachmentCount',
+                Value => 1,
+            }
+        ],
+        Set => [
+            {
+                Key   => 'X-OTRS-DynamicField-TicketFreeText1',
+                Value => 'This should not be set',
+            },
+            {
+                Key   => 'X-OTRS-DynamicField-TicketFreeText2',
+                Value => 'This should not be set',
+            },
+        ],
+        Check => {
+            DynamicField_TicketFreeText1 => undef,
+            DynamicField_TicketFreeText2 => undef,
+        },
+        Email => $EmailInlineImageBadContentIDFormatting,
     },
 );
 

--- a/scripts/test/PostMaster/Attachments.t
+++ b/scripts/test/PostMaster/Attachments.t
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2022 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/scripts/test/sample/PostMaster/InlineImage1.box
+++ b/scripts/test/sample/PostMaster/InlineImage1.box
@@ -1,0 +1,50 @@
+From: test <test@test.com>
+Subject: test
+To: test1 <test1@test.com>
+Message-ID: <test104@test.com>
+Date: Fri, 28 Jul 2017 12:25:43 +0200
+MIME-Version: 1.0
+Content-Type: multipart/alternative;
+ boundary="------------09D1E0375BAA13EBAAD61733"
+Content-Language: pl
+
+This is a multi-part message in MIME format.
+--------------09D1E0375BAA13EBAAD61733
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+test img:
+
+
+--------------09D1E0375BAA13EBAAD61733
+Content-Type: multipart/related;
+ boundary="------------040237935DECF5A5EBB29292"
+
+
+--------------040237935DECF5A5EBB29292
+Content-Type: text/html; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+<html>
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+  </head>
+  <body text="#000000" bgcolor="#FFFFFF">
+    <p><font size="-1"><font face="Verdana">test img: <img
+            src="cid:image1@test.com" alt="" class=""></font></font></p>
+  </body>
+</html>
+
+--------------040237935DECF5A5EBB29292
+Content-Type: image/png;
+ name="test.png"
+Content-Transfer-Encoding: base64
+Content-ID: image1@test.com
+Content-Disposition: attachment;
+ filename="test.png"
+
+iVBORw0KGgoAAAANSUhEUgAAAB4AAAAeAQMAAAAB/jzhAAAAA1BMVEVV5ytwjk3qAAAADElE
+QVQI12NgGIwAAACWAAFiFg3SAAAAAElFTkSuQmCC
+--------------040237935DECF5A5EBB29292--
+
+--------------09D1E0375BAA13EBAAD61733--


### PR DESCRIPTION
## Proposed change

Znuny throws
```
Use of uninitialized value $ImageID in quotemeta at [...]DetectAttachment.pm line 65
```
error when importing e-mail message with inline image with Content-ID header value without <>. Such formatting is not allowed by RFC https://datatracker.ietf.org/doc/html/rfc2392#section-2 but is accepted Znuny in

https://github.com/znuny/Znuny/blob/rel-6_0/Kernel/System/Ticket/Article/Backend/MIMEBase/ArticleStorageFS.pm#L372

so it should tolerate it also in DetectAttachment.pm. This mod fixes it.
    
I also reverts 61cfc740dd3b7b93f81bf8917312eb6c39359c81 because HTML tags and attributes are case insensitive:
    
https://github.com/znuny/Znuny/commit/61cfc740dd3b7b93f81bf8917312eb6c39359c81#commitcomment-110812670

## Type of change
- '1 - 🐞 bug 🐞'            - Bugfix (non-breaking change which fixes an issue)

## Additional information

Replaces: https://github.com/znuny/Znuny/pull/192
Related: https://datatracker.ietf.org/doc/html/rfc2392#section-2
Fixes: 61cfc740dd3b7b93f81bf8917312eb6c39359c81
Author-Change-Id: IB#1114877

## Checklist
- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [x] You improved or added new unit tests.(❕)
- [x] Local ZnunyCodePolicy passed.(❕)
- [x] Local UnitTests / Selenium passed.(❕)
- [ ] GitHub workflow CI (UnitTests / Selenium) passed.(❗)
