### PR TITLE
MariaDB deadlock handling added

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# 6.5.2 ????-??-??
+ - 2023-04-27 MariaDB deadlock handling added.
+
 # 6.5.1 2023-03-09
  - 2023-02-28 Added options tickets-created-before-date and tickets-created-before-days to console command Admin::Article::StorageSwitch.
  - 2023-02-28 Fixed encoding of postmaster filter name in AdminPostMasterFilter.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,3 @@
-# 6.5.2 ????-??-??
- - 2023-04-27 MariaDB deadlock handling added.
-
 # 6.5.1 2023-03-09
  - 2023-02-28 Added options tickets-created-before-date and tickets-created-before-days to console command Admin::Article::StorageSwitch.
  - 2023-02-28 Fixed encoding of postmaster filter name in AdminPostMasterFilter.

--- a/Kernel/System/DB.pm
+++ b/Kernel/System/DB.pm
@@ -1,6 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
-# Copyright (C) 2021-2022 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021 Znuny GmbH, https://znuny.org/
 # Copyright (C) 2022 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
@@ -495,16 +495,16 @@ sub Do {
     return if !$Self->Connect();
 
     # Send SQL query to database.
-    my $RetryLimit = 3; # Retry up to 3 times after deadlock.
+    my $RetryLimit  = 3;    # Retry up to 3 times after deadlock.
     my $QueryStatus = 1;
     TRY:
     for my $Try ( 1 .. $RetryLimit ) {
 
         # Send query to DB.
-        $QueryStatus = $Self->{dbh}->do($Param{SQL}, undef, @Array);
+        $QueryStatus = $Self->{dbh}->do( $Param{SQL}, undef, @Array );
 
         # Don't retry nor sleep on execution success or after last try.
-        last TRY if ( $QueryStatus || ($Try == $RetryLimit) );
+        last TRY if ( $QueryStatus || ( $Try == $RetryLimit ) );
 
         # If error was caused by deadlock, reset $QueryStatus, wait 1s and retry.
 
@@ -513,7 +513,7 @@ sub Do {
         # https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html#error_er_lock_deadlock
         # error code 1213 in MySQL/MariaDB means deadlock
         # (ER_LOCK_DEADLOCK, "Deadlock found when trying to get lock; try restarting transaction").
-        if ( ($DBI::err == 1213) && ($Self->{'DB::Type'} eq 'mysql') ) {
+        if ( ( $DBI::err == 1213 ) && ( $Self->{'DB::Type'} eq 'mysql' ) ) {
             $QueryStatus = 1;
         }
 
@@ -525,14 +525,15 @@ sub Do {
             $Kernel::OM->Get('Kernel::System::Log')->Log(
                 Caller   => 1,
                 Priority => 'debug',
-                Message  => "Deadlock detected by DB server - retrying query in 1s; Try: $Try/$RetryLimit; DB server error: '$DBI::errstr'; DB server error code: $DBI::err; SQL query: '$Param{SQL}'",
+                Message =>
+                    "Deadlock detected by DB server - retrying query in 1s; Try: $Try/$RetryLimit; DB server error: '$DBI::errstr'; DB server error code: $DBI::err; SQL query: '$Param{SQL}'",
             );
         }
 
         # Sleep 1s before resending SQL query to DB.
         sleep(1);
     }
-    if (!$QueryStatus) {
+    if ( !$QueryStatus ) {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Caller   => 1,
             Priority => 'error',

--- a/Kernel/System/DB.pm
+++ b/Kernel/System/DB.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2022 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/System/DB.pm
+++ b/Kernel/System/DB.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
-# Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2021-2022 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2022 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -493,12 +494,49 @@ sub Do {
 
     return if !$Self->Connect();
 
-    # send sql to database
-    if ( !$Self->{dbh}->do( $Param{SQL}, undef, @Array ) ) {
+    # Send SQL query to database.
+    my $RetryLimit = 3; # Retry up to 3 times after deadlock.
+    my $QueryStatus = 1;
+    TRY:
+    for my $Try ( 1 .. $RetryLimit ) {
+
+        # Send query to DB.
+        $QueryStatus = $Self->{dbh}->do($Param{SQL}, undef, @Array);
+
+        # Don't retry nor sleep on execution success or after last try.
+        last TRY if ( $QueryStatus || ($Try == $RetryLimit) );
+
+        # If error was caused by deadlock, reset $QueryStatus, wait 1s and retry.
+
+        # According to
+        # https://mariadb.com/kb/en/mariadb-error-codes/
+        # https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html#error_er_lock_deadlock
+        # error code 1213 in MySQL/MariaDB means deadlock
+        # (ER_LOCK_DEADLOCK, "Deadlock found when trying to get lock; try restarting transaction").
+        if ( ($DBI::err == 1213) && ($Self->{'DB::Type'} eq 'mysql') ) {
+            $QueryStatus = 1;
+        }
+
+        # Don't retry if error was not caused by deadlock.
+        last TRY if !$QueryStatus;
+
+        # Log deadlock if debugging.
+        if ( $Self->{Debug} > 0 ) {
+            $Kernel::OM->Get('Kernel::System::Log')->Log(
+                Caller   => 1,
+                Priority => 'debug',
+                Message  => "Deadlock detected by DB server - retrying query in 1s; Try: $Try/$RetryLimit; DB server error: '$DBI::errstr'; DB server error code: $DBI::err; SQL query: '$Param{SQL}'",
+            );
+        }
+
+        # Sleep 1s before resending SQL query to DB.
+        sleep(1);
+    }
+    if (!$QueryStatus) {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Caller   => 1,
             Priority => 'error',
-            Message  => "$DBI::errstr, SQL: '$Param{SQL}'",
+            Message  => "$DBI::errstr; DB server error code: $DBI::err; SQL query: '$Param{SQL}'",
         );
         return;
     }


### PR DESCRIPTION
## Proposed change

Znuny (checked in v6) occasionally throws MariaDB deadlock errors to its
log (the more concurrency in DB, i.e. more application servers, the more
such errors in time). More deadlocks were noticed after upgrading to
Debian 11 (MariaDB 10.5).

Such deadlocks even if rare (i.e. a few per day) may introduce problems;
for example...

```
DBD::mysql::db do failed: Deadlock found when trying to get lock; try restarting transaction at /opt/otrs/Kernel/System/DB.pm line 471.
ERROR: OTRS-otrs.Daemon.pl - Daemon Kernel::System::Daemon::DaemonModules::SchedulerCronTaskManager-4 Perl: 5.32.1 OS: linux Time: Thu Dec 1 12:05:19 2022

 Message: Deadlock found when trying to get lock; try restarting transaction, SQL: '
            UPDATE scheduler_task
            SET lock_key = 0
            WHERE lock_key = 1 AND id = ?'

 Traceback (4000847):
   Module: Kernel::System::Daemon::SchedulerDB::TaskAdd Line: 172
   Module: Kernel::System::Daemon::SchedulerDB::RecurrentTaskExecute Line: 2151
   Module: Kernel::System::Daemon::SchedulerDB::CronTaskToExecute Line: 1453
   Module: Kernel::System::Daemon::DaemonModules::SchedulerCronTaskManager::Run Line: 103
   Module: (eval) Line: 347
   Module: main::Start Line: 347
   Module: /opt/otrs/bin/otrs.Daemon.pl Line: 163
```
...blocks executions of `MailQueueSend` task (outbound e-mails sending) for
longer time, even over 30mins /until Daemon calls `TaskCleanup()` which removes
broken (`NULL` in `lock_update_time`) task from `scheduler_task` table/. Details
reported by MariaDB show deadlock on index `scheduler_task_lock_key_id`:

```
[...]
  Type: InnoDB
[...]
------------------------
LATEST DETECTED DEADLOCK
------------------------
2022-12-05 02:29:06 0x7f454c2bd700
*** (1) TRANSACTION:
TRANSACTION 458003, ACTIVE 0 sec updating or deleting
mysql tables in use 1, locked 1
LOCK WAIT 5 lock struct(s), heap size 1128, 4 row lock(s), undo log entries 1
MySQL thread id 1132, OS thread handle 139935620974336, query id 33477 myhost [ip] its Updating
UPDATE scheduler_task
            SET lock_key = '100100000838', lock_time = '2022-12-05 01:29:06', lock_update_time = '2022-12-05 01:29:06'
            WHERE lock_key = 0 AND id = '6657'
*** (1) WAITING FOR THIS LOCK TO BE GRANTED:
RECORD LOCKS space id 2143 page no 6 n bits 72 index scheduler_task_lock_key_id of table `its`.`scheduler_task` trx id 458003 lock_mode X insert intention waiting
Record lock, heap no 1 PHYSICAL RECORD: n_fields 1; compact format; info bits 0
 0: len 8; hex 73757072656d756d; asc supremum;;

*** (2) TRANSACTION:
TRANSACTION 458004, ACTIVE 0 sec updating or deleting
mysql tables in use 1, locked 1
4 lock struct(s), heap size 1128, 4 row lock(s), undo log entries 1
MySQL thread id 684, OS thread handle 139935607412480, query id 33478 myhost [ip] its Updating
UPDATE scheduler_task
            SET lock_key = 0
            WHERE lock_key = 1 AND id = '6658'
*** (2) HOLDS THE LOCK(S):
RECORD LOCKS space id 2143 page no 6 n bits 72 index scheduler_task_lock_key_id of table `its`.`scheduler_task` trx id 458004 lock_mode X
Record lock, heap no 1 PHYSICAL RECORD: n_fields 1; compact format; info bits 0
 0: len 8; hex 73757072656d756d; asc supremum;;

Record lock, heap no 2 PHYSICAL RECORD: n_fields 2; compact format; info bits 32
 0: len 8; hex 8000000000000001; asc         ;;
 1: len 8; hex 8000000000001a02; asc         ;;

*** (2) WAITING FOR THIS LOCK TO BE GRANTED:
RECORD LOCKS space id 2143 page no 6 n bits 72 index scheduler_task_lock_key_id of table `its`.`scheduler_task` trx id 458004 lock_mode X locks gap before rec insert intention waiting
Record lock, heap no 2 PHYSICAL RECORD: n_fields 2; compact format; info bits 32
 0: len 8; hex 8000000000000001; asc         ;;
 1: len 8; hex 8000000000001a02; asc         ;;

*** WE ROLL BACK TRANSACTION (2)
[...]

```
Similar problem was noticed (even more often) on `scheduler_recurrent_task_lock_key_id`
index; in this case error sounds like

```
DBD::mysql::db do failed: Deadlock found when trying to get lock; try restarting transaction at /opt/otrs/Kernel/System/DB.pm line 471.
ERROR: OTRS-otrs.Daemon.pl - Daemon Kernel::System::Daemon::DaemonModules::SchedulerCronTaskManager-4 Perl: 5.32.1 OS: linux Time: Mon Dec 5 11:40:02 2022

 Message: Deadlock found when trying to get lock; try restarting transaction, SQL: '
                UPDATE scheduler_recurrent_task
                SET lock_key = 0, lock_time = NULL, last_execution_time = ?, last_worker_task_id = ?,
                    change_time = '2022-12-05 11:40:02'
                WHERE lock_key = ? AND id = ?'

 Traceback (1220524):
   Module: Kernel::System::Daemon::SchedulerDB::RecurrentTaskExecute Line: 2154
   Module: Kernel::System::Daemon::SchedulerDB::CronTaskToExecute Line: 1453
   Module: Kernel::System::Daemon::DaemonModules::SchedulerCronTaskManager::Run Line: 103
   Module: (eval) Line: 347
   Module: main::Start Line: 347
   Module: /opt/otrs/bin/otrs.Daemon.pl Line: 163
```

Znuny [should be prepared to re-issue a transaction](https://dev.mysql.com/doc/refman/5.7/en/innodb-deadlocks-handling.html)
if it fails due to deadlock.

This mod causes Znuny to retry MariaDB queries send using Do() up to 3 times
after MariaDB/MySQL deadlock is detected.

Only `1213` (`ER_LOCK_DEADLOCK`, `Deadlock found when trying to get lock; try restarting transaction`)
MariaDB/MySQL errors are handled as deadlocks now; [other](https://stackoverflow.com/questions/2596005/working-around-mysql-error-deadlock-found-when-trying-to-get-lock-try-restarti/2596101#comment43545045_2596101)
MariaDB/MySQL error codes and/or other database server deadlocks may be added
in similar way in the future if required.

## Type of change
- '1 - 🐞 bug 🐞'            - Bugfix (non-breaking change which fixes an issue)

## Additional information

Replaces: https://github.com/znuny/Znuny/pull/322
Author-Change-Id: IB#1129362

## Checklist
- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [x] Local ZnunyCodePolicy passed.(❕)
- [x] Local UnitTests / Selenium passed.(❕)
- [ ] GitHub workflow CI (UnitTests / Selenium) passed.(❗)
