### PR TITLE
Fixed Popup profile positioning.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,3 @@
-# 6.5.3 ????-??-??
- - 2023-05-13 Popup profile positioning and UI fixed
-
 # 6.5.2 2023-04-19
  - 2023-04-13 Activated information section and modal dialog for ICS calendar events in AgentTicketZoom view.
  - 2023-04-05 Fixed format of returned filename in function Kernel::System::Stats::StringAndTimestamp2Filename.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# 6.5.3 ????-??-??
+ - 2023-05-13 Popup profile positioning and UI fixed
+
 # 6.5.2 2023-04-19
  - 2023-04-13 Activated information section and modal dialog for ICS calendar events in AgentTicketZoom view.
  - 2023-04-05 Fixed format of returned filename in function Kernel::System::Stats::StringAndTimestamp2Filename.

--- a/Kernel/Config/Files/XML/Framework.xml
+++ b/Kernel/Config/Files/XML/Framework.xml
@@ -3468,7 +3468,7 @@ You can log in via the following URL:
             </Hash>
         </Value>
     </Setting>
-    <Setting Name="PreferencesGroups###PopupProfile" Required="0" Valid="1">
+    <Setting Name="PreferencesGroups###PopupProfile" Required="0" Valid="0">
         <Description Translatable="1">Defines the global users popup profile.</Description>
         <Navigation>Frontend::Agent::View::Preferences</Navigation>
         <Value>

--- a/var/httpd/htdocs/js/Core.UI.Popup.js
+++ b/var/httpd/htdocs/js/Core.UI.Popup.js
@@ -1,6 +1,7 @@
 // --
 // Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 // Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+// Copyright (C) 2023 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 // --
 // This software comes with ABSOLUTELY NO WARRANTY. For details, see
 // the enclosed file COPYING for license information (GPL). If you
@@ -513,6 +514,12 @@ Core.UI.Popup = (function (TargetNS) {
                 if (WindowMode === 'Popup') {
                     PopupFeatures = PopupProfiles[PopupProfile].WindowURLParams;
 
+                    // Convert strings to numbers to avoid surprises like concatenation instead of sum.
+                    PopupProfiles[PopupProfile].Width = Number(PopupProfiles[PopupProfile].Width);
+                    PopupProfiles[PopupProfile].Height = Number(PopupProfiles[PopupProfile].Height);
+                    PopupProfiles[PopupProfile].Top = Number(PopupProfiles[PopupProfile].Top);
+                    PopupProfiles[PopupProfile].Left = Number(PopupProfiles[PopupProfile].Left);
+
                     // get pixel or percent of width and height
                     // convert to a valid pixel value for window.open
                     Regex        = new RegExp('(%|px)$');
@@ -531,7 +538,7 @@ Core.UI.Popup = (function (TargetNS) {
 
                     // Get the position of the current screen on browsers which support it (non-IE) and
                     // use it to open the popup on the same screen
-                    PopupFeatures += ',left=' + ((window.screen.left || 0) + PopupProfiles[PopupProfile].Left);
+                    PopupFeatures += ',left=' + PopupProfiles[PopupProfile].Left;
                     PopupFeatures += ',width=' + PopupProfiles[PopupProfile].Width;
 
                     // Bug#11205 (http://bugs.otrs.org/show_bug.cgi?id=11205)
@@ -543,11 +550,11 @@ Core.UI.Popup = (function (TargetNS) {
                     if (window.screen.availHeight < PopupProfiles[PopupProfile].Height + PopupProfiles[PopupProfile].Top) {
                         PopupFeatures += ',height=' + (window.screen.availHeight - PopupProfiles[PopupProfile].Top - 20);
                         // Adjust top position to have the same distance between top and bottom line.
-                        PopupFeatures += ',top=' + ((window.screen.top || 0) + (PopupProfiles[PopupProfile].Top / 2));
+                        PopupFeatures += ',top=' + (PopupProfiles[PopupProfile].Top / 2);
                     }
                     else {
                         PopupFeatures += ',height=' + PopupProfiles[PopupProfile].Height;
-                        PopupFeatures += ',top=' + ((window.screen.top || 0) + PopupProfiles[PopupProfile].Top);
+                        PopupFeatures += ',top=' + PopupProfiles[PopupProfile].Top;
                     }
 
                     NewWindow = window.open(URL, WindowName, PopupFeatures);

--- a/var/httpd/htdocs/js/Core.UI.Popup.js
+++ b/var/httpd/htdocs/js/Core.UI.Popup.js
@@ -1,7 +1,6 @@
 // --
 // Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 // Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-// Copyright (C) 2023 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 // --
 // This software comes with ABSOLUTELY NO WARRANTY. For details, see
 // the enclosed file COPYING for license information (GPL). If you


### PR DESCRIPTION
## Proposed change

Popup profile `top`, `left`, `width` and `height` parameter values should be interpreted by JS as numbers not strings (`left` popup value was contcatenation not sum of `window.screen.left` and `PopupProfiles[PopupProfile].Left` and was producing wrong popup positioning).

Popup positioning on dual monitor setup in Firefox was broken because `screenX` returns position on spanned screen not current screen and according to

https://developer.mozilla.org/en-US/docs/Web/API/Screen/top
https://developer.mozilla.org/en-US/docs/Web/API/Screen/left

`window.screen.top` and `window.screen.left` are non-standard/obsolete and should be avoided.

This fixes these positioning problems.

There is no point in displaying `Popup Profile` in agent preferences by default (may be helpful for debugging only) because it's now automatically updated on popup resize so it's hidden now by default.

## Type of change

- '1 - 🐞 bug 🐞'            - Bugfix (non-breaking change which fixes an issue)

## Additional information

Fixes: a20eddf94b64dc30ecf92910fb7bc4b16c4cf612
Related: https://github.com/znuny/Znuny/issues/432
Author-Change-Id: IB#1133822

## Checklist

- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [x] Local ZnunyCodePolicy passed.(❕)
- [x] Local UnitTests / Selenium passed.(❕)
- [ ] GitHub workflow CI (UnitTests / Selenium) passed.(❗)
