### PR TITLE
Incorrect display of empty HTML article body fixed.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# 6.5.2 ????-??-??
+ - 2023-04-27 Incorrect display of empty HTML article body fixed.
+
 # 6.5.1 2023-03-09
  - 2023-02-28 Added options tickets-created-before-date and tickets-created-before-days to console command Admin::Article::StorageSwitch.
  - 2023-02-28 Fixed encoding of postmaster filter name in AdminPostMasterFilter.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,3 @@
-# 6.5.2 ????-??-??
- - 2023-04-27 Incorrect display of empty HTML article body fixed.
-
 # 6.5.1 2023-03-09
  - 2023-02-28 Added options tickets-created-before-date and tickets-created-before-days to console command Admin::Article::StorageSwitch.
  - 2023-02-28 Fixed encoding of postmaster filter name in AdminPostMasterFilter.

--- a/Kernel/Modules/AgentTicketArticleContent.pm
+++ b/Kernel/Modules/AgentTicketArticleContent.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2022 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/Modules/AgentTicketArticleContent.pm
+++ b/Kernel/Modules/AgentTicketArticleContent.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2022 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -79,7 +80,7 @@ sub Run {
         ArticleID => $ArticleID,
     );
 
-    if ( !$ArticleContent ) {
+    if ( !defined($ArticleContent) ) {
         $LogObject->Log(
             Message  => 'No such article!',
             Priority => 'error',


### PR DESCRIPTION
## Proposed change

Znuny incorrectly displays articles with empty HTML bodies (error screen
is displayed in the article iframe instead of empty body).

Example email message displayed incorrectly in Znuny:

```
From test@localhost  Tue Jan 11 09:35:34 2022
Content-Type: multipart/mixed; boundary="------------0E7SVvKDzD4zuBIUOmJEz90l"
Message-ID: <20220111001@localhost>
Date: Tue, 11 Jan 2022 09:35:31 +0100
MIME-Version: 1.0
From: test <test@localhost>
Subject: test
To: otrs@localhost
Content-Language: pl-PL

This is a multi-part message in MIME format.
--------------0E7SVvKDzD4zuBIUOmJEz90l
Content-Type: multipart/alternative;
 boundary="------------Ykl0SZabNei1x2Mr2CwcTukE"

--------------Ykl0SZabNei1x2Mr2CwcTukE
Content-Transfer-Encoding: quoted-printable
Content-Type: text/plain; charset="UTF-8"

=0D

--------------Ykl0SZabNei1x2Mr2CwcTukE
Content-Transfer-Encoding: quoted-printable
Content-Type: text/html; charset="UTF-8"

--------------Ykl0SZabNei1x2Mr2CwcTukE--

--------------0E7SVvKDzD4zuBIUOmJEz90l
Content-Type: text/plain; charset=windows-1250;
 name="test.txt"
Content-Disposition: attachment; filename="test.txt"
Content-Transfer-Encoding: 8bit

test

--------------0E7SVvKDzD4zuBIUOmJEz90l--

```

This mod fixes the above issue.

## Type of change
- '1 - 🐞 bug 🐞'            - Bugfix (non-breaking change which fixes an issue)


## Additional information
Replaces: https://github.com/znuny/Znuny/pull/187
Author-Change-Id: IB#1114565

## Checklist
<!--
  Put an 'x' in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  ❕ - nice to have
  ❗ - required before review
-->

- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [x] Local ZnunyCodePolicy run passes successfully.(❕)
- [x] Local unit tests pass.(❕)
- [ ] GitHub workflow ZnunyCodePolicy passes.(❗)
- [ ] GitHub workflow unit tests pass.(❗)
