### PR TITLE
Fixed AdminPGP missing breadcrumb entry and failing Selenium test.

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AdminPGP.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminPGP.tt
@@ -99,10 +99,7 @@
         </div>
 [% RenderBlockEnd("Hint") %]
     </div>
-[% RenderBlockStart("OverviewResult") %]
-
     <div class="ContentColumn">
-        <h1 class="InvisibleText">[% Translate("PGP Management") | html %]</h1>
 
         [% BreadcrumbPath = [
                 {
@@ -118,6 +115,7 @@
 
         [% INCLUDE "Breadcrumb.tt" Path = BreadcrumbPath %]
 
+[% RenderBlockStart("OverviewResult") %]
         <div class="WidgetSimple">
             <div class="Header">
                 <h2>[% Translate("List") | html %]</h2>
@@ -171,10 +169,8 @@
                 </table>
             </div>
         </div>
-    </div>
 [% RenderBlockEnd("OverviewResult") %]
 [% RenderBlockStart("AddKey") %]
-    <div class="ContentColumn">
         <div class="WidgetSimple">
             <div class="Header">
                 <h2>[% Translate("Add PGP Key") | html %]</h2>
@@ -206,7 +202,7 @@
                 </form>
             </div>
         </div>
-    </div>
 [% RenderBlockEnd("AddKey") %]
+    </div>
 </div>
 [% RenderBlockEnd("Overview") %]

--- a/scripts/test/Selenium/Agent/Admin/AdminPGP.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminPGP.t
@@ -20,8 +20,8 @@ my $Selenium = $Kernel::OM->Get('Kernel::System::UnitTest::Selenium');
 $Selenium->RunTest(
     sub {
 
-        my $ConfigObject   = $Kernel::OM->Get('Kernel::Config');
-        my $HelperObject   = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+        my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+        my $HelperObject = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
 
         # Create test user and login.
         my $TestUserLogin = $HelperObject->TestUserCreate(

--- a/scripts/test/Selenium/Agent/Admin/AdminPGP.t
+++ b/scripts/test/Selenium/Agent/Admin/AdminPGP.t
@@ -21,7 +21,6 @@ $Selenium->RunTest(
     sub {
 
         my $ConfigObject   = $Kernel::OM->Get('Kernel::Config');
-        my $CryptPGPObject = $Kernel::OM->Get('Kernel::System::Crypt::PGP');
         my $HelperObject   = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
 
         # Create test user and login.
@@ -155,7 +154,7 @@ $Selenium->RunTest(
 
         # Delete test PGP keys.
         for my $Count ( 1 .. 2 ) {
-            my @Keys = $CryptPGPObject->KeySearch(
+            my @Keys = $Kernel::OM->Get('Kernel::System::Crypt::PGP')->KeySearch(
                 Search => $PGPKey{$Count},
             );
 


### PR DESCRIPTION
<!--
  You are amazing! 🚀
  Thanks for contributing to the Znuny community project!
  Please, DO NOT DELETE ANY TEXT from this template (unless instructed)!

### Licensing, copyright and credits

Znuny is an open fork of an existing software. So we have to respect the already given copyright of the original creators.

New files will be licensed using the AGPL Version 3. If you contribute code to the Znuny project you will get mentioned in the pull request incl. the commit, in CHANGES.md and in AUTHORS.md. We will not mention you in the file you provided or changed. Your work is highly appreciated and acknowledged but you contribute it to the project and your copyright will pass on to the fork itself.
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why this pull request should be accepted. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
A breadcrumb entry in AdminPGP was missing after the template update. 

Additionally, the test (Selenium/Agent/Admin/AdminPGP.t) failed because of this and because the Crypt object has to be created in the loop.
<!--
## Type of change
  What type of change does your PR introduce to Znuny?
  NOTE: Please add only one label with a starting '1 - ' to this PR!
  If your PR requires multiple labels to be applied, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster for the code review.

- '1 - 🆙 dependency upgrade - Dependency upgrade (e.g. libraries)
- '1 - 🐞 bug 🐞'            - Bugfix (non-breaking change which fixes an issue)
- '1 - 💎 code quality'      - Code quality improvements to existing code or addition of unit tests
- '1 - 🚀 feature'           - New feature (which adds functionality to an existing integration)
- '1 - ...'

-->
1 - 🐞 bug 🐞

## Checklist
<!--
  Put an 'x' in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  ❕ - nice to have
  ❗ - required before review
-->

- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [x] You improved or added new unit tests.(❕)
- [x] Local ZnunyCodePolicy passed.(❕)
- [x] Local UnitTests / Selenium passed.(❕)
- [ ] GitHub workflow CI (UnitTests / Selenium) passed.(❗)

<!--
  Thank you for contributing ❤

  Znuny @znuny/znuny
-->
