### PR TITLE
Fixed extra space causing uninitialized value error.

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketOverviewSmall.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketOverviewSmall.tt
@@ -265,7 +265,7 @@
 [% RenderBlockEnd("RecordTicketColumnTranslatable") %]
 [% RenderBlockStart("RecordTicketColumnTime") %]
                     <td>
-                        <div title="[% Data.GenericValue | Localize(" TimeShort") | html %]">[% Data.GenericValue | Localize("TimeShort") | html %]</div>
+                        <div title="[% Data.GenericValue | Localize("TimeShort") | html %]">[% Data.GenericValue | Localize("TimeShort") | html %]</div>
                     </td>
 [% RenderBlockEnd("RecordTicketColumnTime") %]
 [% RenderBlockStart("RecordTicketColumnEscalation") %]


### PR DESCRIPTION
<!--
  You are amazing! 🚀
  Thanks for contributing to the Znuny community project!
  Please, DO NOT DELETE ANY TEXT from this template (unless instructed)!

### Licensing, copyright and credits

Znuny is an open fork of an existing software. So we have to respect the already given copyright of the original creators.

New files will be licensed using the AGPL Version 3. If you contribute code to the Znuny project you will get mentioned in the pull request incl. the commit, in CHANGES.md and in AUTHORS.md. We will not mention you in the file you provided or changed. Your work is highly appreciated and acknowledged but you contribute it to the project and your copyright will pass on to the fork itself.
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why this pull request should be accepted. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

An extra space is causing a Template Toolkit function to falsely read the value of the argument given to it. This causes the value to not be rendered in HTML. Moreover, an error entry is being created in the Apache error log.

<!--
## Type of change
  What type of change does your PR introduce to Znuny?
  NOTE: Please add only one label with a starting '1 - ' to this PR!
  If your PR requires multiple labels to be applied, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster for the code review.

- '1 - 🆙 dependency upgrade - Dependency upgrade (e.g. libraries)
- '1 - 🐞 bug 🐞'            - Bugfix (non-breaking change which fixes an issue)
- '1 - 💎 code quality'      - Code quality improvements to existing code or addition of unit tests
- '1 - 🚀 feature'           - New feature (which adds functionality to an existing integration)
- '1 - ...'

-->

## Type of change

🐞 bug 🐞


## Additional information
<!--
  Details are important and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  Note: Remove this section if not needed.

  If a PR is related to an issue, please use the 'Linked issues' function on the sidebar.
-->

Steps to reproduce:

- Go to AgentTicketStatusView
- Activate the column "Created", if necessary (or another datetime column)
- Open Apache error log (`tail -f /var/log/httpd/error_log`)
- Reload page in browser
- Inspect field value in browser with debugger and note that the value of the attruibute title is empty
-  Error message: `index.pl: Use of uninitialized value in concatenation (.) or string at /opt/znuny/Kernel/Output/HTML/Templates/Standard/AgentTicketOverviewSmall.tt line 202.`



<!--
- This PR is related to PR: #
- ...
-->

## Checklist
<!--
  Put an 'x' in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  ❕ - nice to have
  ❗ - required before review
-->

- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [ ] Local ZnunyCodePolicy passed.(❕)
- [ ] Local UnitTests / Selenium passed.(❕)
- [ ] GitHub workflow CI (UnitTests / Selenium) passed.(❗)

<!--
  Thank you for contributing ❤

  Znuny @znuny/znuny
-->
