### PR TITLE
Sector Nord AG: Resolved CTRL+left click on ticket error message.

### DIFF
--- a/var/httpd/htdocs/js/Core.Agent.Overview.js
+++ b/var/httpd/htdocs/js/Core.Agent.Overview.js
@@ -280,7 +280,7 @@ Core.Agent.Overview = (function (TargetNS) {
             // only act if the link was not clicked directly
             if (Event.target !== $MasterActionLink.get(0)) {
                 if (Event.ctrlKey || Event.metaKey) {
-                    Core.UI.Popup.open($MasterActionLink.attr('href'));
+                    Core.UI.Popup.OpenPopup($MasterActionLink.attr('href'));
                 }
                 else {
                     window.location = $MasterActionLink.attr('href');
@@ -361,7 +361,7 @@ Core.Agent.Overview = (function (TargetNS) {
             // only act if the link was not clicked directly
             if (Event.target !== $MasterActionLink.get(0)) {
                 if (Event.ctrlKey || Event.metaKey) {
-                    Core.UI.Popup.open($MasterActionLink.attr('href'));
+                    Core.UI.Popup.OpenPopup($MasterActionLink.attr('href'));
                 }
                 else {
                     window.location = $MasterActionLink.attr('href');
@@ -505,7 +505,7 @@ Core.Agent.Overview = (function (TargetNS) {
             // only act if the link was not clicked directly
             if (Event.target !== $MasterActionLink.get(0)) {
                 if (Event.ctrlKey || Event.metaKey) {
-                    Core.UI.Popup.open($MasterActionLink.attr('href'));
+                    Core.UI.Popup.OpenPopup($MasterActionLink.attr('href'));
                 }
                 else {
                     window.location = $MasterActionLink.attr('href');


### PR DESCRIPTION
<!--
  You are amazing! 🚀
  Thanks for contributing to the Znuny community project!
  Please, DO NOT DELETE ANY TEXT from this template (unless instructed)!

### Licensing, copyright and credits

Znuny is an open fork of an existing software. So we have to respect the already given copyright of the original creators.

New files will be licensed using the AGPL Version 3. If you contribute code to the Znuny project you will get mentioned in the pull request incl. the commit, in CHANGES.md and in AUTHORS.md. We will not mention you in the file you provided or changed. Your work is highly appreciated and acknowledged but you contribute it to the project and your copyright will pass on to the fork itself.
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why this pull request should be accepted. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When clicking on a ticket in the AgentTicketStatusView with Ctrl pressed, the following error message appears in the browser console:


```
Core.Agent.Overview.js:283 Uncaught TypeError: Core.UI.Popup.open is not a function
    at HTMLTableRowElement.<anonymous> (Core.Agent.Overview.js:283:35)
    at HTMLTableRowElement.dispatch (jquery.js:2:43064)
    at v.handle (jquery.js:2:41048)
```

The problem seems to be related to a syntax error in Core.Agent.Overview.js:

```javascript
 if (Event.target !== $MasterActionLink.get(0)) {
                if (Event.ctrlKey || Event.metaKey) {
                    Core.UI.Popup.open($MasterActionLink.attr('href')); <-- `here is the syntax error`
                }
                else {
                    window.location = $MasterActionLink.attr('href');
                }
                return false;
            }
```
The syntax error apprears in all three views


<!--
## Type of change
  What type of change does your PR introduce to Znuny?
  NOTE: Please add only one label with a starting '1 - ' to this PR!
  If your PR requires multiple labels to be applied, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster for the code review.

- '1 - 🆙 dependency upgrade - Dependency upgrade (e.g. libraries)
- '1 - 🐞 bug 🐞'            - Bugfix (non-breaking change which fixes an issue)
- '1 - 💎 code quality'      - Code quality improvements to existing code or addition of unit tests
- '1 - 🚀 feature'           - New feature (which adds functionality to an existing integration)
- '1 - ...'

-->
## Type of change

🐞 bug 🐞

## Additional information
<!--
  Details are important and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  Note: Remove this section if not needed.

  If a PR is related to an issue, please use the 'Linked issues' function on the sidebar.
-->
### Steps to reproduce
- Navigate to AgentTicketStatusView
- Open the broweser console through DevTools
- While holding Ctrl, left click on one of the displayed tickets
- Observe the error message displayed in the browser console

<!--
- This PR is related to PR: #
- ...
-->

## Checklist
<!--
  Put an 'x' in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  ❕ - nice to have
  ❗ - required before review
-->

- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [ ] Local ZnunyCodePolicy passed.(❕)
- [ ] Local UnitTests / Selenium passed.(❕)
- [ ] GitHub workflow CI (UnitTests / Selenium) passed.(❗)

<!--
  Thank you for contributing ❤

  Znuny @znuny/znuny
-->
