### PR TITLE
Sector Nord AG: Textarea element now expands in both directions.

### DIFF
--- a/var/httpd/htdocs/skins/Agent/default/css/Core.Form.css
+++ b/var/httpd/htdocs/skins/Agent/default/css/Core.Form.css
@@ -84,7 +84,7 @@ did not receive this file, see https://www.gnu.org/licenses/gpl-3.0.txt.
     textarea {
         /*min-width: 120px;
         min-width: 100%;*/
-        flex: 1;
+        flex: 1 auto;
         padding: 6px var(--padding-sm);
     }
 


### PR DESCRIPTION
<!--
  You are amazing! 🚀
  Thanks for contributing to the Znuny community project!
  Please, DO NOT DELETE ANY TEXT from this template (unless instructed)!

### Licensing, copyright and credits

Znuny is an open fork of an existing software. So we have to respect the already given copyright of the original creators.

New files will be licensed using the AGPL Version 3. If you contribute code to the Znuny project you will get mentioned in the pull request incl. the commit, in CHANGES.md and in AUTHORS.md. We will not mention you in the file you provided or changed. Your work is highly appreciated and acknowledged but you contribute it to the project and your copyright will pass on to the fork itself.
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why this pull request should be accepted. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The `<textarea>` element currently only expands in one direction, usually horizontally. This causes issue when writing longer text in the field. As it stands `<textarea>` holds the CSS property `flex: 1;`, an abbreviation of the three proprieties `flex-grow: 1; flex-shrink: 1; flex-basis: 0%;`. The issue is being caused by the property `flex-basis: 0%;`, because it sets the initial width to 0, but leaves the height unaltered by the flex property ( in the case the flex container is set to a row orientation).

The proposed change is to change the value of the flex property from `flex: 1;` to `flex: 1 auto;`, which adjusts the initial width and height, which in turn allows the flex container to adjust both values on expansion. This change would set the new values to `flex-grow: 1; flex-shrink: 1; flex-basis: auto;`.

<!--
## Type of change
  What type of change does your PR introduce to Znuny?
  NOTE: Please add only one label with a starting '1 - ' to this PR!
  If your PR requires multiple labels to be applied, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster for the code review.

- '1 - 🆙 dependency upgrade - Dependency upgrade (e.g. libraries)
- '1 - 🐞 bug 🐞'            - Bugfix (non-breaking change which fixes an issue)
- '1 - 💎 code quality'      - Code quality improvements to existing code or addition of unit tests
- '1 - 🚀 feature'           - New feature (which adds functionality to an existing integration)
- '1 - ...'

-->
## Type of change

🐞 bug 🐞

## Additional information
<!--
  Details are important and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  Note: Remove this section if not needed.

  If a PR is related to an issue, please use the 'Linked issues' function on the sidebar.
-->
 
Many areas were tested ti see if this change creates and unwanted effects.
These areas include:
- SQL-Box
- Deactivated Richtext-Editor boxes
-  AdminProcessManagement, AdminProcessManagementActivityDialog and it's popup window
- Dynamic fields in masks
- Various other admin masks e.g AdminAutoResponse


<!--
- This PR is related to PR: #
- ...
-->

## Checklist
<!--
  Put an 'x' in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  ❕ - nice to have
  ❗ - required before review
-->

- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [ ] Local ZnunyCodePolicy passed.(❕)
- [ ] Local UnitTests / Selenium passed.(❕)
- [ ] GitHub workflow CI (UnitTests / Selenium) passed.(❗)

<!--
  Thank you for contributing ❤

  Znuny @znuny/znuny
-->
