### PR TITLE
SectorNordAG: Clicking 'Enter' inside of <input> triggers wrong event.

### DIFF
--- a/var/httpd/htdocs/js/Core.Form.js
+++ b/var/httpd/htdocs/js/Core.Form.js
@@ -292,7 +292,7 @@ Core.Form = (function (TargetNS) {
         // Once there was any modification, do not check it any more.
         $("form input, select, textarea").off('change', FormModified);
     }
-    
+
     /**
      * This makes all forms submittable by using Enter inside inputs.
      */
@@ -314,6 +314,7 @@ Core.Form = (function (TargetNS) {
             // a few useful event handlers tied to it, like validation.
             $(this.form).find(':submit').last().click();
         }
+        Event.preventDefault()
     });
 
     Core.Init.RegisterNamespace(TargetNS, 'APP_MODULE');

--- a/var/httpd/htdocs/js/Core.Form.js
+++ b/var/httpd/htdocs/js/Core.Form.js
@@ -298,7 +298,7 @@ Core.Form = (function (TargetNS) {
      */
     $('body').on('keydown', 'input', function (Event) {
         if (Event.keyCode == 13) {
-            Event.preventDefault()
+            Event.preventDefault();
             $('form').find(':submit').last().click();
         }
     });

--- a/var/httpd/htdocs/js/Core.Form.js
+++ b/var/httpd/htdocs/js/Core.Form.js
@@ -298,9 +298,9 @@ Core.Form = (function (TargetNS) {
      */
     $('body').on('keydown', 'input', function (Event) {
         if (Event.keyCode == 13) {
+            Event.preventDefault()
             $('form').find(':submit').last().click();
         }
-        Event.preventDefault()
     });
 
     /**
@@ -312,9 +312,9 @@ Core.Form = (function (TargetNS) {
         if ((Event.ctrlKey || Event.metaKey) && Event.keyCode == 13) {
             // We need to click() instead of submit(), since click() has
             // a few useful event handlers tied to it, like validation.
+            Event.preventDefault()
             $(this.form).find(':submit').last().click();
         }
-        Event.preventDefault()
     });
 
     Core.Init.RegisterNamespace(TargetNS, 'APP_MODULE');

--- a/var/httpd/htdocs/js/Core.Form.js
+++ b/var/httpd/htdocs/js/Core.Form.js
@@ -292,6 +292,16 @@ Core.Form = (function (TargetNS) {
         // Once there was any modification, do not check it any more.
         $("form input, select, textarea").off('change', FormModified);
     }
+    
+    /**
+     * This makes all forms submittable by using Enter inside inputs.
+     */
+    $('body').on('keydown', 'input', function (Event) {
+        if (Event.keyCode == 13) {
+            $('form').find(':submit').last().click();
+        }
+        Event.preventDefault()
+    });
 
     /**
      * This makes all forms submittable by using Ctrl+Enter inside textareas.
@@ -302,7 +312,7 @@ Core.Form = (function (TargetNS) {
         if ((Event.ctrlKey || Event.metaKey) && Event.keyCode == 13) {
             // We need to click() instead of submit(), since click() has
             // a few useful event handlers tied to it, like validation.
-            $(this.form).find(':submit').first().click();
+            $(this.form).find(':submit').last().click();
         }
     });
 

--- a/var/httpd/htdocs/js/Core.Form.js
+++ b/var/httpd/htdocs/js/Core.Form.js
@@ -312,7 +312,7 @@ Core.Form = (function (TargetNS) {
         if ((Event.ctrlKey || Event.metaKey) && Event.keyCode == 13) {
             // We need to click() instead of submit(), since click() has
             // a few useful event handlers tied to it, like validation.
-            Event.preventDefault()
+            Event.preventDefault();
             $(this.form).find(':submit').last().click();
         }
     });


### PR DESCRIPTION
<!--
  You are amazing! 🚀
  Thanks for contributing to the Znuny community project!
  Please, DO NOT DELETE ANY TEXT from this template (unless instructed)!

### Licensing, copyright and credits

Znuny is an open fork of an existing software. So we have to respect the already given copyright of the original creators.

New files will be licensed using the AGPL Version 3. If you contribute code to the Znuny project you will get mentioned in the pull request incl. the commit, in CHANGES.md and in AUTHORS.md. We will not mention you in the file you provided or changed. Your work is highly appreciated and acknowledged but you contribute it to the project and your copyright will pass on to the fork itself.
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why this pull request should be accepted. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

On a page with both **Save as new draft** and **Submit** buttons, clicking the _Enter_ key inside a `<input>` box triggers the **Save as new draft** button by default. This behaviour is not consistent with the same pages in Znuny6.

In order to fix this behaviour,  the following code could be added to Core.Form.js to handle this situation. 

```
    $('body').on('keydown', 'input', function (Event) {
        if (Event.keyCode == 13) {
            $('form').find(':submit').last().click();
        }
        Event.preventDefault()
    });

```
Additionally, the code that handles the user attempting to submit a form from within a `<textarea>` when `Frontend::RichText` is disabled could be updated to similarly trigger the expected button by changing the logic of how the button is selected. Currently it selects the first element with the type **submit**, which it mistakenly believes to be **save as new draft**, changing this to `last()` instead will trigger the expected button. 

```
    $('body').on('keydown', 'textarea', function (Event) {
        if ((Event.ctrlKey || Event.metaKey) && Event.keyCode == 13) {
            // We need to click() instead of submit(), since click() has
            // a few useful event handlers tied to it, like validation.
            $(this.form).find(':submit').last().click();
        }
        Event.preventDefault()
    });
```

## Type of change
<!--
## Type of change
  What type of change does your PR introduce to Znuny?
  NOTE: Please add only one label with a starting '1 - ' to this PR!
  If your PR requires multiple labels to be applied, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster for the code review.

- '1 - 🆙 dependency upgrade - Dependency upgrade (e.g. libraries)
- '1 - 🐞 bug 🐞'            - Bugfix (non-breaking change which fixes an issue)
- '1 - 💎 code quality'      - Code quality improvements to existing code or addition of unit tests
- '1 - 🚀 feature'           - New feature (which adds functionality to an existing integration)
- '1 - ...'

-->

 '1 - 🐞 bug 🐞'


<!--
  If your PR contains a breaking change, it is important
  to tell what breaks, how to make it work again and why it is necessary.
  This piece of text is published with the release notes, so it helps if you
  write it for the users, not the maintainer.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Additional information
<!--
  Details are important and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  Note: Remove this section if not needed.

  If a PR is related to an issue, please use the 'Linked issues' function on the sidebar.
-->
### Replication 
- Navigate to `AgentTicketZoom`
- Click on **Communication** and select **Note**
- Enter some dummy information in both **Subject** and **Text**, click inside of **Subject** and click __Enter__
- You will be presented with the **Add new draft** popup instead of the form submitting


<!--
- This PR is related to PR: #
- ...
-->

## Checklist
<!--
  Put an 'x' in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  ❕ - nice to have
  ❗ - required before review
-->

- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [ ] Local ZnunyCodePolicy passed.(❕)
- [ ] Local UnitTests / Selenium passed.(❕)
- [ ] GitHub workflow CI (UnitTests / Selenium) passed.(❗)

<!--
  Thank you for contributing ❤

  Znuny @znuny/znuny
-->
