### PR TITLE
CKeditor's autogrow feature disabled

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,3 @@
-# 6.5.6 ????-??-??
- - 2023-12-28 CKeditor's autogrow feature disabled.
-
 # 6.5.5 2023-12-13
  - 2023-12-11 Increased size of user_id column in table customer_user_customer.
  - 2023-12-07 Customer detail search cache for dynamic field values will now be cleared if a customer will be added or updated.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# 6.5.6 ????-??-??
+ - 2023-12-28 CKeditor's autogrow feature disabled.
+
 # 6.5.5 2023-12-13
  - 2023-12-11 Increased size of user_id column in table customer_user_customer.
  - 2023-12-07 Customer detail search cache for dynamic field values will now be cleared if a customer will be added or updated.

--- a/var/httpd/htdocs/js/Core.UI.RichTextEditor.js
+++ b/var/httpd/htdocs/js/Core.UI.RichTextEditor.js
@@ -307,7 +307,7 @@ Core.UI.RichTextEditor = (function (TargetNS) {
 
         // set default editor config, but allow custom config for other types for editors
         /*eslint-disable camelcase */
-        RemovedCKEditorPlugins = 'devtools,image,flash,mathjax,embed,exportpdf,sourcedialog,bbcode,divarea,elementspath,stylesheetparser';
+        RemovedCKEditorPlugins = 'devtools,image,flash,mathjax,embed,exportpdf,sourcedialog,bbcode,divarea,elementspath,stylesheetparser,autogrow';
         if (!CheckFormID($EditorArea).length) {
             RemovedCKEditorPlugins += ',uploadimage';
         }
@@ -320,7 +320,6 @@ Core.UI.RichTextEditor = (function (TargetNS) {
             width:                     Core.Config.Get('RichText.Width', 620),
             resize_minWidth:           Core.Config.Get('RichText.Width', 620),
             height:                    Core.Config.Get('RichText.Height', 320),
-            autoGrow_minHeight:        Core.Config.Get('RichText.Height', 320),
             removePlugins:             RemovedCKEditorPlugins,
             forcePasteAsPlainText:     false,
             format_tags:               Core.Config.Get('RichText.FormatTags', 'p;h1;h2;h3;h4;h5;h6;pre'),


### PR DESCRIPTION
## Proposed change
CKeditor's autogrow feature enabled in Znuny 6.5.5 makes article textarea height autogrowing without limits which makes editing long articles hard (i.e. forces user to scroll page between text selections and editor menu during font changes).

This mod disables autogrow feature like in Znuny 6.5.4-.

## Type of change
- '1 - 🐞 bug 🐞'            - Bugfix (non-breaking change which fixes an issue)

## Additional information
Author-Change-Id: IB#1141742

## Checklist
- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [x] Local ZnunyCodePolicy passed.(❕)
- [x] Local UnitTests / Selenium passed.(❕)
- [ ] GitHub workflow CI (UnitTests / Selenium) passed.(❗)
