### PR TITLE
Sector Nord AG: Bugfix: Hide empty dynamic info/dynamic field box

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketActionCommon.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketActionCommon.tt
@@ -277,7 +277,6 @@
                         [% END %]
 
 [% RenderBlockStart("TicketTypeDynamicFields") %]
-                        [% IF !TicketFrontendConfig.DynamicField.empty %]
                         <div class="dynamic-field-col card-item col-wide-100 col-desktop-100 col-tablet-100">
                             <h2 class="card-title">[% Translate("Dynamic Info") | html %]</h2>
 [% RenderBlockStart("TicketTypeDynamicField") %]
@@ -289,7 +288,6 @@
                                 </div>
 [% RenderBlockEnd("TicketTypeDynamicField") %]
                         </div>
-                        [% END %]
 [% RenderBlockEnd("TicketTypeDynamicFields") %]
 
 # Example of how to use fixed dynamic field blocks for customizations. Block below is for fields of type 'Ticket'.

--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketCompose.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketCompose.tt
@@ -66,7 +66,7 @@
                         </div>
                     </div>
                 </div>
-                [% IF !TicketFrontendConfig.DynamicField.empty %]
+                [% IF Data.DynamicFieldHTML && Data.DynamicFieldHTML.list.size > 0 %]
                 <div class="card-item col-desktop-100 col-wide-100">
                     <h2 class="card-title">[% Translate("Dynamic Info") | html %]</h2>
 [% RenderBlockStart("DynamicField") %]

--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketEmail.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketEmail.tt
@@ -385,7 +385,7 @@
                             </div>
                         </div>
                     </div>
-                    [% IF !Data.DynamicFieldHTML.empty %]
+                    [% IF Data.DynamicFieldHTML && Data.DynamicFieldHTML.list.size > 0 %]
                     <div class="dynamic-field-col card-item col-wide-66 col-desktop-100 col-tablet-100">
                         <h2 class="card-title">[% Translate("Dynamic Info") | html %]</h2>
 [% RenderBlockStart("DynamicField") %]

--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketEmailOutbound.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketEmailOutbound.tt
@@ -309,7 +309,7 @@
                     </div>
                 </div>
 
-                [% IF !TicketFrontendConfig.DynamicField.empty %]
+                [% IF Data.DynamicFieldHTML && Data.DynamicFieldHTML.list.size > 0 %]
                 <div class="dynamic-field-col card-item col-wide-100 col-desktop-100 col-tablet-100">
                     <h2 class="card-title">[% Translate("Dynamic Info") | html %]</h2>
 [% RenderBlockStart("DynamicField") %]

--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketForward.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketForward.tt
@@ -62,7 +62,7 @@
                         </div>
                     </div>
                 </div>
-                [% IF !TicketFrontendConfig.DynamicField.empty %]
+                [% IF Data.DynamicFieldHTML && Data.DynamicFieldHTML.list.size > 0 %]
                 <div class="card-item col-desktop-100 col-wide-100">
                     <h2 class="card-title">[% Translate("Dynamic Info") | html %]</h2>
 [% RenderBlockStart("DynamicField") %]

--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketNoteToLinkedTicket.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketNoteToLinkedTicket.tt
@@ -274,7 +274,6 @@
                         [% END %]
 
 [% RenderBlockStart("TicketTypeDynamicFields") %]
-                        [% IF !TicketFrontendConfig.DynamicField.empty %]
                         <div class="dynamic-field-col card-item col-wide-100 col-desktop-100 col-tablet-100">
                             <h2 class="card-title">[% Translate("Dynamic Info") | html %]</h2>
 [% RenderBlockStart("TicketTypeDynamicField") %]
@@ -286,7 +285,6 @@
                                 </div>
 [% RenderBlockEnd("TicketTypeDynamicField") %]
                         </div>
-                        [% END %]
 [% RenderBlockEnd("TicketTypeDynamicFields") %]
 
 

--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketPhone.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketPhone.tt
@@ -250,7 +250,7 @@
         </div>
     </div>
 
-[% IF !TicketFrontendConfig.DynamicField.empty %]
+[% IF Data.DynamicFieldHTML && Data.DynamicFieldHTML.list.size > 0 %]
     <div class="dynamic-field-col card-item col-wide-66 col-desktop-100 col-tablet-100">
         <h2 class="card-title">[% Translate("Dynamic Info") | html %]</h2>
 [% RenderBlockStart("DynamicField") %]

--- a/Kernel/Output/HTML/Templates/Standard/AgentTicketPhoneCommon.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentTicketPhoneCommon.tt
@@ -79,7 +79,7 @@
                         </div>
                         [% END %]
 
-                        [% IF !TicketFrontendConfig.DynamicField.empty %]
+                        [% IF Data.DynamicFieldHTML && Data.DynamicFieldHTML.list.size > 0 %]
                         <div class="dynamic-field-col card-item col-wide-100 col-desktop-100 col-tablet-100">
                             <h2 class="card-title">[% Translate("Dynamic Info") | html %]</h2>
 [% RenderBlockStart("DynamicField") %]

--- a/Kernel/Output/HTML/Templates/Standard/CustomerTicketMessage.tt
+++ b/Kernel/Output/HTML/Templates/Standard/CustomerTicketMessage.tt
@@ -112,7 +112,7 @@
                         </div>
                     </div>
                     [% END %]
-                    [% IF !TicketFrontendConfig.DynamicField.empty %]
+                    [% IF Data.DynamicFieldHTML && Data.DynamicFieldHTML.list.size > 0 %]
                     <div class="card-item col-wide-100 col-desktop-100 col-tablet-100">
                         <h2 class="card-title">[% Translate("Dymanic Info") | html %]</h2>
                         <div class="active-inner-cols">


### PR DESCRIPTION
<!--
  You are amazing! 🚀
  Thanks for contributing to the Znuny community project!
  Please, DO NOT DELETE ANY TEXT from this template (unless instructed)!

### Licensing, copyright and credits

Znuny is an open fork of an existing software. So we have to respect the already given copyright of the original creators.

New files will be licensed using the AGPL Version 3. If you contribute code to the Znuny project you will get mentioned in the pull request incl. the commit, in CHANGES.md and in AUTHORS.md. We will not mention you in the file you provided or changed. Your work is highly appreciated and acknowledged but you contribute it to the project and your copyright will pass on to the fork itself.
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why this pull request should be accepted. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

In some cases the widget "Dynamic Fields" or "Dynamic Info" are shown empty.

![image](https://github.com/znuny/Znuny/assets/91074418/daae247f-45c8-479d-a3ab-f76cc3ed4edc)

I have found two causes for the problem. Both problems should be solved by my change.

1. The variable in the code `[% IF !TicketFrontendConfig.DynamicField.empty %]` is not always empty.
If you configure a dynamic field in a screen as deactivated, it will occure in the variable `TicketFrontendConfig.DynamicField`.

![image](https://github.com/znuny/Znuny/assets/91074418/475bd1d9-4760-4495-afd6-4e998b2c20d4)

2. The method `empty()` in the code `[% IF !TicketFrontendConfig.DynamicField.empty %]` does not return the correct value in older versions of template toolkit.

On CentOS 7, perl v5.16.3, Template Toolkit 2.24, the method `TicketFrontendConfig.DynamicField.empty` returns "".

On Oracle 9.3, perl v5.32.1, Template Toolkit 3.009, under the same circumstances, the method returns "1".

I tested the following code in AgentTicketPhone.tt on both systems:

```
[% USE Dumper %]
[% Dumper.dump(TicketFrontendConfig.DynamicField) %]
[% Dumper.dump(TicketFrontendConfig.DynamicField.empty) %]
[% Dumper.dump(Data.DynamicFieldHTML.list.size) %]   # my suggestion
```

Output Template Toolkit 2.24:
```
$VAR1 = {}; 
$VAR1 = '';    # wrong
$VAR1 = 0;    # my suggestion
```

Output Template Toolkit 3.009:
```
$VAR1 = {}; 
$VAR1 = 1;    # correct
$VAR1 = 0;    # my suggestion
```

## Type of change
<!--
  What type of change does your PR introduce to Znuny?
  NOTE: Please add only one label with a starting '1 - ' to this PR!
  If your PR requires multiple labels to be applied, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster for the code review.

- '1 - 🆙 dependency upgrade - Dependency upgrade (e.g. libraries)
- '1 - 🐞 bug 🐞'            - Bugfix (non-breaking change which fixes an issue)
- '1 - 💎 code quality'      - Code quality improvements to existing code or addition of unit tests
- '1 - 🚀 feature'           - New feature (which adds functionality to an existing integration)
- '1 - ...'

-->

- '1 - 🐞 bug 🐞'

## Additional information
<!--
  Details are important and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  Note: Remove this section if not needed.

  If a PR is related to an issue, please use the 'Linked issues' function on the sidebar.
-->

I also removed the condition from AgentTicketActionCommon.tt and AgentTicketNoteToLinkedTicket.tt because the dynamic fields are added to these masks through the RenderBlock methods.

I did my best to test all different masks on both systems with activated, disabled and not selected dynamic fields.

<!--
- This PR is related to PR: #
- ...
-->

## Checklist
<!--
  Put an 'x' in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  ❕ - nice to have
  ❗ - required before review
-->

- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [ ] Local ZnunyCodePolicy passed.(❕)
- [ ] Local UnitTests / Selenium passed.(❕)
- [ ] GitHub workflow CI (UnitTests / Selenium) passed.(❗)

<!--
  Thank you for contributing ❤

  Znuny @znuny/znuny
-->
