### PR TITLE
Sector Nord AG: Fixed overflow of dynamic field groups in AgentTicketZoom process widget 

### DIFF
--- a/var/httpd/htdocs/skins/Agent/default/css/Core.Agent.TicketProcess.css
+++ b/var/httpd/htdocs/skins/Agent/default/css/Core.Agent.TicketProcess.css
@@ -47,15 +47,12 @@ did not receive this file, see https://www.gnu.org/licenses/gpl-3.0.txt.
         background-color: #fff;
         padding: 4px 7px 2px 7px;
         font-size: 11px;
-    }
+    }*/
 
     .WidgetSimple > .Content.ProcessInfo fieldset .FieldContainer p.CutValue {
-        text-overflow: ellipsis;
         height: 17px;
-        overflow: hidden;
-        display: block;
-        white-space: nowrap;
-    }*/
+        max-width: 600px;
+    }
 
     .WidgetSimple > .Content.ProcessInfo fieldset .FieldContainer p.ValueLong {
         display: none;


### PR DESCRIPTION
<!--
  You are amazing! 🚀
  Thanks for contributing to the Znuny community project!
  Please, DO NOT DELETE ANY TEXT from this template (unless instructed)!

### Licensing, copyright and credits

Znuny is an open fork of an existing software. So we have to respect the already given copyright of the original creators.

New files will be licensed using the AGPL Version 3. If you contribute code to the Znuny project you will get mentioned in the pull request incl. the commit, in CHANGES.md and in AUTHORS.md. We will not mention you in the file you provided or changed. Your work is highly appreciated and acknowledged but you contribute it to the project and your copyright will pass on to the fork itself.
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why this pull request should be accepted. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

If the value of a dynamic field is too long, the dynamic field widgets overflows to the right.

![image](https://github.com/znuny/Znuny/assets/91074418/001a85fe-b392-4a8d-af3b-ed4c9ab63bcb)

Steps to reproduce:

* Add a process to the process management. The process has to include at least an activity dialog with three dynamic fields. One field should be a textarea.
* Add the dynamic fields to `Ticket::Frontend::AgentTicketZoom###ProcessWidgetDynamicField`
* (Optional) Add three dynamic fields to a group: `Ticket::Frontend::AgentTicketZoom###ProcessWidgetDynamicFieldGroups`
* Create a process ticket, use a long text for the textarea field. (I added my text below)
* Go to the AgentTicketZoom mask and the widget should now look like my screenshot.

It is interesting to note that as soon as any widget contains text that is too large, all the widgets no longer adapts to the window size.

The same widget with a shorter text:

![image](https://github.com/znuny/Znuny/assets/91074418/673475d4-64e2-467f-ad65-3cf463bb39cf)

* There may be different ways to fix the issue. I found the CSS class `CutValue` that was used in the `AgentTicketZoom.tt`. In the CSS file `Core.Agent.TicketProcess.css` the class `CutValue` was commented out before, so I recycled it.
* You can also reproduce the bug with normal sized Full HD monitors if you use four dynamic fields in the widget. (So it is not just a problem for small monitor users! 😄  )

My example text:
```
Znuny is the continuation of the OTRS Project created in 2001 by Martin Edenhofer. OTRS AG discontinued maintenance of the ((OTRS)) Community Edition in 2020. Martin’s company Znuny GmbH then forked the project to continue it under the name Znuny.

Since then the software has continued to grow, as never before, through contributions from many open-source support vendors and the hard work and financial backing from Znuny GmbH.
```

## Type of change
<!--
  What type of change does your PR introduce to Znuny?
  NOTE: Please add only one label with a starting '1 - ' to this PR!
  If your PR requires multiple labels to be applied, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster for the code review.

- '1 - 🆙 dependency upgrade - Dependency upgrade (e.g. libraries)
- '1 - 🐞 bug 🐞'            - Bugfix (non-breaking change which fixes an issue)
- '1 - 💎 code quality'      - Code quality improvements to existing code or addition of unit tests
- '1 - 🚀 feature'           - New feature (which adds functionality to an existing integration)
- '1 - ...'

-->

- '1 - 🐞 bug 🐞' 

## Additional information
<!--
  Details are important and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  Note: Remove this section if not needed.

  If a PR is related to an issue, please use the 'Linked issues' function on the sidebar.
-->

I also found the following code snippet in the `AgentTicketZoom.tt`:
```
                                        <p class="ValueLong">
[% RenderBlockStart("ProcessWidgetDynamicFieldValueLong") %]
                                            [% Data.Value %]
[% RenderBlockEnd("ProcessWidgetDynamicFieldValueLong") %]
                                        </p>
```

I did not find the perl code that inserts the blocks. The code may be unnecessary.

<!--
- This PR is related to PR: #
- ...
-->

## Checklist
<!--
  Put an 'x' in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  ❕ - nice to have
  ❗ - required before review
-->

- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [ ] Local ZnunyCodePolicy passed.(❕)
- [ ] Local UnitTests / Selenium passed.(❕)
- [ ] GitHub workflow CI (UnitTests / Selenium) passed.(❗)

<!--
  Thank you for contributing ❤

  Znuny @znuny/znuny
-->
