### PR TITLE
Sector Nord AG: Editing own extended agent preferences is not possible

### DIFF
--- a/Kernel/Modules/AgentPreferences.pm
+++ b/Kernel/Modules/AgentPreferences.pm
@@ -40,7 +40,6 @@ sub Run {
 
     if (
         $EditUserID
-        && $EditUserID != $Self->{UserID}
         && $Self->_CheckEditPreferencesPermission()
         )
     {


### PR DESCRIPTION
<!--
  You are amazing! 🚀
  Thanks for contributing to the Znuny community project!
  Please, DO NOT DELETE ANY TEXT from this template (unless instructed)!

### Licensing, copyright and credits

Znuny is an open fork of an existing software. So we have to respect the already given copyright of the original creators.

New files will be licensed using the AGPL Version 3. If you contribute code to the Znuny project you will get mentioned in the pull request incl. the commit, in CHANGES.md and in AUTHORS.md. We will not mention you in the file you provided or changed. Your work is highly appreciated and acknowledged but you contribute it to the project and your copyright will pass on to the fork itself.
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why this pull request should be accepted. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Some agent preferences can only be edited by admins, e.g. `PreferencesGroups###Comment`.
To edit them you need to go to:  
Admin -> Agents -> Choose an agent -> "Edit personal preferences for this agent" -> "Miscellaneous"

Since [this commit](https://github.com/znuny/Znuny/commit/a9dd66c9bfb653cc8226fa950b9da9cdb2a71218) there is a bug when editing the own "extended" preferences.

When clicking on "Edit personal preferences for this agent" the URL contains the UserID of the target user that should be edited: `/znuny/index.pl?Action=AgentPreferences;EditUserID=1`

If I am UserID 1 and want to edit UserID 1 the parameter is beeing removed after clicking on "Miscellaneous": `/znuny/index.pl?Action=AgentPreferences;Subaction=Group;Group=Miscellaneous`

If I edit another User, the URL contains the parameter correctly: `/znuny/index.pl?Action=AgentPreferences;Subaction=Group;Group=Miscellaneous;EditUserID=2`

If the parameter "EditUserID" is missing, not all agent preferences are shown, e.g. "Comment" is missing. So it is not possible to edit the comment preferences for the own user. You need to ask a different admin user or add the parameter "EditUserID" to the URL.

## Type of change
<!--
  What type of change does your PR introduce to Znuny?
  NOTE: Please add only one label with a starting '1 - ' to this PR!
  If your PR requires multiple labels to be applied, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster for the code review.

- '1 - 🆙 dependency upgrade - Dependency upgrade (e.g. libraries)
- '1 - 🐞 bug 🐞'            - Bugfix (non-breaking change which fixes an issue)
- '1 - 💎 code quality'      - Code quality improvements to existing code or addition of unit tests
- '1 - 🚀 feature'           - New feature (which adds functionality to an existing integration)
- '1 - ...'

-->
- '1 - 🐞 bug 🐞' 

## Additional information
<!--
  Details are important and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  Note: Remove this section if not needed.

  If a PR is related to an issue, please use the 'Linked issues' function on the sidebar.
-->

I found out that the bug was built into Znuny 7 with this commit:  https://github.com/znuny/Znuny/commit/a9dd66c9bfb653cc8226fa950b9da9cdb2a71218

I have also tested changing the settings of another agent as an agent (not admin) by adding the parameter manually. However, this is correctly recognized and intercepted by Znuny, so that it is not possible to change other settings without permission.

<!--
- This PR is related to PR: #
- ...
-->

## Checklist
<!--
  Put an 'x' in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  ❕ - nice to have
  ❗ - required before review
-->

- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [x] Local ZnunyCodePolicy passed.(❕)
- [ ] Local UnitTests / Selenium passed.(❕)
- [ ] GitHub workflow CI (UnitTests / Selenium) passed.(❗)

<!--
  Thank you for contributing ❤

  Znuny @znuny/znuny
-->
