### PR TITLE
Efflux: Avoid generating error logs by installer.pl

### DIFF
--- a/Kernel/Modules/Installer.pm
+++ b/Kernel/Modules/Installer.pm
@@ -1154,8 +1154,9 @@ sub ConnectToDB {
         );
     }
 
+    # Connect to the database without logging errors, as they are already shown to the user.
     my $DBH = DBI->connect(
-        $Param{DSN}, $Param{DBUser}, $Param{DBPassword},
+        $Param{DSN}, $Param{DBUser}, $Param{DBPassword}, { PrintError => 0 }
     );
 
     if ( !$DBH ) {

--- a/Kernel/Output/HTML/Layout.pm
+++ b/Kernel/Output/HTML/Layout.pm
@@ -1310,7 +1310,7 @@ sub Header {
 
     # Generate the minified CSS and JavaScript files and the tags referencing them (see LayoutLoader)
     $Self->LoaderCreateAgentCSSCalls();
-    if ( !$Self->{InstallerOnly}  ) {
+    if ( !$Self->{InstallerOnly} ) {
         $Self->LoaderCreateDynamicCSS();
     }
 

--- a/Kernel/Output/HTML/Layout.pm
+++ b/Kernel/Output/HTML/Layout.pm
@@ -1310,7 +1310,9 @@ sub Header {
 
     # Generate the minified CSS and JavaScript files and the tags referencing them (see LayoutLoader)
     $Self->LoaderCreateAgentCSSCalls();
-    $Self->LoaderCreateDynamicCSS();
+    if ( !$Self->{InstallerOnly}  ) {
+        $Self->LoaderCreateDynamicCSS();
+    }
 
     my %AgentLogo;
 
@@ -1758,10 +1760,14 @@ sub Footer {
     }
 
     # Set an array with pending states.
-    my @PendingStateIDs = $Kernel::OM->Get('Kernel::System::State')->StateGetStatesByType(
-        StateType => [ 'pending reminder', 'pending auto' ],
-        Result    => 'ID',
-    );
+    my @PendingStateIDs;
+
+    if ( !$Self->{InstallerOnly} ) {
+        @PendingStateIDs = $Kernel::OM->Get('Kernel::System::State')->StateGetStatesByType(
+            StateType => [ 'pending reminder', 'pending auto' ],
+            Result    => 'ID',
+        );
+    }
 
     # add JS data
     my %JSConfig = (

--- a/Kernel/System/Package.pm
+++ b/Kernel/System/Package.pm
@@ -2571,7 +2571,11 @@ sub PackageInstallDefaultFiles {
     # get main object
     my $MainObject = $Kernel::OM->Get('Kernel::System::Main');
 
-    my $Directory    = $Self->{ConfigObject}->Get('Home') . '/var/packages';
+    my $Directory = $Self->{ConfigObject}->Get('Home') . '/var/packages';
+
+    # Return if the directory does not exist.
+    return if !-e $Directory;
+
     my @PackageFiles = $MainObject->DirectoryRead(
         Directory => $Directory,
         Filter    => '*.opm',


### PR DESCRIPTION
## Proposed change
The installer.pl generates numerous error messages during the installation of Znuny – even if everything works fine. This PR tries to eliminate some/most of them.


## Type of change
- '1 - 🐞 bug 🐞'            - Bugfix (non-breaking change which fixes an issue)


## Additional information
**Kernel/Modules/Installer.pm**: `PrintError` makes sure failed database calls don't get handled by Perl (→ the web server). Every major error will either get directly shown to the user via `$DBI::errstr` or there is an existing translation message attached to it. Just by checking that the database is empty (by checking if the `valid` table exists), an error message gets created. Most of the other checks will also get logged as errors.

**Kernel/System/Package.pm**: `var/packages` will most likely not exist on > 95% of the installed systems. The subroutine does currently not check if the directory exists and throws an error.

**Kernel/Output/HTML/Layout.pm**: Both subroutines that got wrapped into the `InstallerOnly` check, make direct calls to the database, which does not exist yet (or at least shouldn't). `InstallerOnly` doesn't get used anywhere else, but it feels like this is a perfect use for it.

I don't think internal checks should write error messages to the log. This might give the wrong (first) impression that something went wrong or could have been done better.


## Checklist
- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [x] Local ZnunyCodePolicy passed.(❕)
- [ ] Local UnitTests / Selenium passed.(❕)
- [ ] GitHub workflow CI (UnitTests / Selenium) passed.(❗)