### PR TITLE
Efflux: Disable logging of plaintext passwords in debugging mode (CVE-2024-43444)

### DIFF
--- a/Kernel/System/Auth/DB.pm
+++ b/Kernel/System/Auth/DB.pm
@@ -89,7 +89,7 @@ sub Auth {
     my $RemoteAddr = $ENV{REMOTE_ADDR} || 'Got no REMOTE_ADDR env!';
     my $UserID     = '';
     my $GetPw      = '';
-    my $Method;
+    my $Method     = '';
 
     # get database object
     my $DBObject = $Kernel::OM->Get('Kernel::System::DB');
@@ -177,8 +177,8 @@ sub Auth {
             {
                 $Kernel::OM->Get('Kernel::System::Log')->Log(
                     Priority => 'error',
-                    Message =>
-                        "User: '$User' tried to authenticate with bcrypt but 'Crypt::Eksblowfish::Bcrypt' is not installed!",
+                    Message  =>
+                        "User: $User tried to authenticate with bcrypt but 'Crypt::Eksblowfish::Bcrypt' is not installed!",
                 );
                 return;
             }
@@ -245,10 +245,19 @@ sub Auth {
 
     # just in case for debug!
     if ( $Self->{Debug} > 0 ) {
+        my $EnteredPw  = $CryptedPw;
+        my $ExpectedPw = $GetPw;
+
+        # Don't log plaintext passwords.
+        if ( $Method eq 'plain' ) {
+            $EnteredPw  = 'xxx';
+            $ExpectedPw = 'xxx';
+        }
+
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'notice',
-            Message =>
-                "User: '$User' tried to authenticate with Pw: '$Pw' ($UserID/$Method/$CryptedPw/$GetPw/$Salt/$RemoteAddr)",
+            Message  =>
+                "User: $User tried to authenticate (User ID: $UserID, method: $Method, entered password: $EnteredPw, expected password: $ExpectedPw, salt: $Salt, remote address: $RemoteAddr)",
         );
     }
 
@@ -275,7 +284,7 @@ sub Auth {
     elsif ( ($UserID) && ($GetPw) ) {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'notice',
-            Message =>
+            Message  =>
                 "User: $User authentication with wrong Pw!!! (Method: $Method, REMOTE_ADDR: $RemoteAddr)"
         );
         return;

--- a/Kernel/System/Auth/LDAP.pm
+++ b/Kernel/System/Auth/LDAP.pm
@@ -151,7 +151,7 @@ sub Auth {
         if ( $Self->{Debug} > 0 ) {
             $Kernel::OM->Get('Kernel::System::Log')->Log(
                 Priority => 'notice',
-                Message  => "User: ($Param{User}) added $Self->{UserSuffix} to username!",
+                Message  => "User: $Param{User} added $Self->{UserSuffix} to username!",
             );
         }
     }
@@ -160,8 +160,7 @@ sub Auth {
     if ( $Self->{Debug} > 0 ) {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'notice',
-            Message  => "User: '$Param{User}' tried to authenticate with Pw: '$Param{Pw}' "
-                . "(REMOTE_ADDR: $RemoteAddr)",
+            Message  => "User: $Param{User} tried to authenticate (REMOTE_ADDR: $RemoteAddr)",
         );
     }
 

--- a/Kernel/System/Auth/Radius.pm
+++ b/Kernel/System/Auth/Radius.pm
@@ -85,7 +85,7 @@ sub Auth {
     if ( $Self->{Debug} > 0 ) {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'notice',
-            Message  => "User: '$User' tried to authenticate with Pw: '$Pw' ($RemoteAddr)",
+            Message  => "User: $User tried to authenticate (REMOTE_ADDR: $RemoteAddr)",
         );
     }
 

--- a/Kernel/System/CustomerAuth/LDAP.pm
+++ b/Kernel/System/CustomerAuth/LDAP.pm
@@ -152,7 +152,7 @@ sub Auth {
         if ( $Self->{Debug} > 0 ) {
             $Kernel::OM->Get('Kernel::System::Log')->Log(
                 Priority => 'notice',
-                Message  => "CustomerUser: ($Param{User}) added $Self->{UserSuffix} to username!",
+                Message  => "CustomerUser: $Param{User} added $Self->{UserSuffix} to username!",
             );
         }
     }
@@ -161,8 +161,7 @@ sub Auth {
     if ( $Self->{Debug} > 0 ) {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'notice',
-            Message  => "CustomerUser: '$Param{User}' tried to authenticate with Pw: '$Param{Pw}' "
-                . "(REMOTE_ADDR: $RemoteAddr)",
+            Message  => "CustomerUser: $Param{User} tried to authenticate (REMOTE_ADDR: $RemoteAddr)",
         );
     }
 
@@ -248,7 +247,7 @@ sub Auth {
         if ( $Self->{Debug} > 0 ) {
             $Kernel::OM->Get('Kernel::System::Log')->Log(
                 Priority => 'notice',
-                Message  => 'check for groupdn!',
+                Message  => 'Checking for GroupDN.',
             );
         }
 
@@ -288,7 +287,7 @@ sub Auth {
             # failed login note
             $Kernel::OM->Get('Kernel::System::Log')->Log(
                 Priority => 'notice',
-                Message =>
+                Message  =>
                     "CustomerUser: $Param{User} authentication failed, no LDAP group entry found"
                     . "GroupDN='$Self->{GroupDN}', Filter='$Filter2'! (REMOTE_ADDR: $RemoteAddr).",
             );

--- a/Kernel/System/CustomerAuth/Radius.pm
+++ b/Kernel/System/CustomerAuth/Radius.pm
@@ -88,7 +88,7 @@ sub Auth {
     if ( $Self->{Debug} > 0 ) {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'notice',
-            Message  => "User: '$User' tried to authenticate with Pw: '$Pw' ($RemoteAddr)",
+            Message  => "CustomerUser: $User tried to authenticate (REMOTE_ADDR: $RemoteAddr)",
         );
     }
 
@@ -133,7 +133,7 @@ sub Auth {
     if ( defined($AuthResult) && $AuthResult == 1 ) {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'notice',
-            Message  => "User: $User Authentication ok (REMOTE_ADDR: $RemoteAddr).",
+            Message  => "CustomerUser: $User Authentication ok (REMOTE_ADDR: $RemoteAddr).",
         );
         return $User;
     }
@@ -142,7 +142,7 @@ sub Auth {
     else {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'notice',
-            Message  => "User: $User Authentication with wrong Pw!!! (REMOTE_ADDR: $RemoteAddr)"
+            Message  => "CustomerUser: $User Authentication with wrong Pw!!! (REMOTE_ADDR: $RemoteAddr)"
         );
         return;
     }


### PR DESCRIPTION
## Proposed change
Disable the logging of plaintext passwords in debugging mode.
## Type of change
- 1 - 🐞 bug 🐞

## Additional information
This is inspired by CVE-2024-43444. I'd not consider this a security patch, as the debugging mode can only be enabled by changing the source code. And if you have access to the source code, you can debug anything.

## Checklist
<!--
  Put an 'x' in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  ❕ - nice to have
  ❗ - required before review
-->

- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [x] Local ZnunyCodePolicy passed.(❕)
- [ ] Local UnitTests / Selenium passed.(❕)
- [ ] GitHub workflow CI (UnitTests / Selenium) passed.(❗)