### PR TITLE
Fix S/MIME certificate removal and messaging

### DIFF
--- a/Kernel/Language/pl.pm
+++ b/Kernel/Language/pl.pm
@@ -1,7 +1,7 @@
 # --
 # Copyright (C) 2003-2010 Tomasz Melissa <janek at rumianek.com>
 # Copyright (C) 2009 Artur Skalski <skal.ar at wp.pl>
-# Copyright (C) 2011 Informatyka Boguslawski sp. z o.o. sp.k., https://www.ib.pl/
+# Copyright (C) 2011-2013 Informatyka Boguslawski sp. z o.o. sp.k., https://www.ib.pl/
 # Copyright (C) 2014 Wojciech Myrda <wmyrda at auticon.pl>, http://www.auticon.pl
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
@@ -2028,19 +2028,6 @@ sub Data {
         'Available Certificates' => 'Dostępne certyfikaty',
         'Filter for S/MIME certs' => 'Filtruj certyfikaty S/MIME',
         'Relate this certificate' => 'Powiąż ten certyfikat',
-        'Error removing private key, certificate removing aborted: %s!' => 'Błąd przy usuwaniu klucza prywatnego, usuwanie certyfikatu anulowane: %s!',
-        'Certificate and its private key removed' => 'Certyfikat i jego klucz prywatny usunięte',
-        'Error removing certificate, only its private key was removed: %s!' => 'Błąd przy usuwaniu certyfikatu, usunięty został tylko jego klucz prywatny: %s!',
-        'Certificate removed' => 'Certyfikat usunięty',
-        'Certificate already installed!' => 'Certyfikat jest już zainstalowany!',
-        'Certificate uploaded' => 'Certyfikat załadowany',
-        'Private key uploaded' => 'Klucz prywatny załadowany',
-        'Can\'t add invalid private key!' => 'Nie mogę dodać niepoprawnego klucza prywatnego!',
-        'Can\'t add invalid certificate!' => 'Nie mogę dodać niepoprawnego certyfikatu!',
-        'No more available filenames for certificate hash:%s!' => 'Brak dalszych nazw plików dla skrótu certyfikatu:%s!',
-        'No private key!' => 'Brak klucza prywatnego!',
-        'Certificate for private key not found (upload it first) or invalid private key or invalid password: %s!' => 'Brak certyfikatu do klucza prywatnego (załaduj go najpierw) lub niepoprawny klucz prywatny lub niepoprawne hasło: %s!',
-        'Private key deleted' => 'Klucz prywatny usunięty',
 
         # TT Template: Kernel/Output/HTML/Templates/Standard/AdminSMIMECertRead.tt
         'S/MIME Certificate' => 'Certyfikat S/MIME',
@@ -8331,7 +8318,7 @@ sub Data {
         'Are you sure you want to overwrite the config parameters?' => '',
 
         # JS File: var/httpd/htdocs/js/Core.Agent.Admin.SMIME.js
-        'Do you really want to delete this item?' => 'Czy na pewno chcesz usunąć ten element?',
+        'Do you really want to delete this certificate?' => '',
 
         # JS File: var/httpd/htdocs/js/Core.Agent.Admin.SupportDataCollector.js
         'Sending Update...' => 'Wysyłanie aktualizacji...',

--- a/Kernel/Language/pl.pm
+++ b/Kernel/Language/pl.pm
@@ -1,7 +1,7 @@
 # --
 # Copyright (C) 2003-2010 Tomasz Melissa <janek at rumianek.com>
 # Copyright (C) 2009 Artur Skalski <skal.ar at wp.pl>
-# Copyright (C) 2011-2013 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
+# Copyright (C) 2011 Informatyka Boguslawski sp. z o.o. sp.k., https://www.ib.pl/
 # Copyright (C) 2014 Wojciech Myrda <wmyrda at auticon.pl>, http://www.auticon.pl
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
@@ -2028,6 +2028,19 @@ sub Data {
         'Available Certificates' => 'Dostępne certyfikaty',
         'Filter for S/MIME certs' => 'Filtruj certyfikaty S/MIME',
         'Relate this certificate' => 'Powiąż ten certyfikat',
+        'Error removing private key, certificate removing aborted: %s!' => 'Błąd przy usuwaniu klucza prywatnego, usuwanie certyfikatu anulowane: %s!',
+        'Certificate and its private key removed' => 'Certyfikat i jego klucz prywatny usunięte',
+        'Error removing certificate, only its private key was removed: %s!' => 'Błąd przy usuwaniu certyfikatu, usunięty został tylko jego klucz prywatny: %s!',
+        'Certificate removed' => 'Certyfikat usunięty',
+        'Certificate already installed!' => 'Certyfikat jest już zainstalowany!',
+        'Certificate uploaded' => 'Certyfikat załadowany',
+        'Private key uploaded' => 'Klucz prywatny załadowany',
+        'Can\'t add invalid private key!' => 'Nie mogę dodać niepoprawnego klucza prywatnego!',
+        'Can\'t add invalid certificate!' => 'Nie mogę dodać niepoprawnego certyfikatu!',
+        'No more available filenames for certificate hash:%s!' => 'Brak dalszych nazw plików dla skrótu certyfikatu:%s!',
+        'No private key!' => 'Brak klucza prywatnego!',
+        'Certificate for private key not found (upload it first) or invalid private key or invalid password: %s!' => 'Brak certyfikatu do klucza prywatnego (załaduj go najpierw) lub niepoprawny klucz prywatny lub niepoprawne hasło: %s!',
+        'Private key deleted' => 'Klucz prywatny usunięty',
 
         # TT Template: Kernel/Output/HTML/Templates/Standard/AdminSMIMECertRead.tt
         'S/MIME Certificate' => 'Certyfikat S/MIME',
@@ -8318,7 +8331,7 @@ sub Data {
         'Are you sure you want to overwrite the config parameters?' => '',
 
         # JS File: var/httpd/htdocs/js/Core.Agent.Admin.SMIME.js
-        'Do you really want to delete this certificate?' => '',
+        'Do you really want to delete this item?' => 'Czy na pewno chcesz usunąć ten element?',
 
         # JS File: var/httpd/htdocs/js/Core.Agent.Admin.SupportDataCollector.js
         'Sending Update...' => 'Wysyłanie aktualizacji...',

--- a/Kernel/Language/pl.pm
+++ b/Kernel/Language/pl.pm
@@ -1,7 +1,7 @@
 # --
 # Copyright (C) 2003-2010 Tomasz Melissa <janek at rumianek.com>
 # Copyright (C) 2009 Artur Skalski <skal.ar at wp.pl>
-# Copyright (C) 2011-2013 Informatyka Boguslawski sp. z o.o. sp.k., https://www.ib.pl/
+# Copyright (C) 2011-2013 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 # Copyright (C) 2014 Wojciech Myrda <wmyrda at auticon.pl>, http://www.auticon.pl
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/

--- a/Kernel/Modules/AdminSMIME.pm
+++ b/Kernel/Modules/AdminSMIME.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2025 Informatyka Boguslawski sp. z o.o. sp.k., https://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/Modules/AdminSMIME.pm
+++ b/Kernel/Modules/AdminSMIME.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2025 Informatyka Boguslawski sp. z o.o. sp.k., https://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -172,11 +173,6 @@ sub Run {
                         }
                     }
                 }
-            }
-
-            if ( defined $Attributes{Private} && $Attributes{Private} eq 'Yes' ) {
-                %Result = $SMIMEObject->PrivateRemove( Filename => $Filename );
-                push @Result, \%Result if %Result;
             }
         }
 

--- a/Kernel/System/Crypt/SMIME.pm
+++ b/Kernel/System/Crypt/SMIME.pm
@@ -1328,10 +1328,10 @@ sub CertificateRemove {
     # Remove certificate.
     my $Cert = unlink "$Self->{CertPath}/$Param{Filename}";
     if ( !$Cert ) {
-        $Message
-            = $LayoutObject->{LanguageObject}
-            ->Translate( 'Error removing certificate, only its private key was removed: %s!',
-            "$Self->{CertPath}/$Param{Filename}: $!" );
+        $Message = $LayoutObject->{LanguageObject}->Translate(
+            'Error removing certificate, only its private key was removed: %s!',
+            "$Self->{CertPath}/$Param{Filename}: $!"
+        );
         $Success = 0;
     }
 

--- a/Kernel/System/Crypt/SMIME.pm
+++ b/Kernel/System/Crypt/SMIME.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2025 Informatyka Boguslawski sp. z o.o. sp.k., https://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/System/Crypt/SMIME.pm
+++ b/Kernel/System/Crypt/SMIME.pm
@@ -7,6 +7,7 @@
 # the enclosed file COPYING for license information (GPL). If you
 # did not receive this file, see https://www.gnu.org/licenses/gpl-3.0.txt.
 # --
+## nofilter(TidyAll::Plugin::Znuny::Perl::LayoutObject)
 
 package Kernel::System::Crypt::SMIME;
 

--- a/Kernel/System/Crypt/SMIME.pm
+++ b/Kernel/System/Crypt/SMIME.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2025 Informatyka Boguslawski sp. z o.o. sp.k., https://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -16,6 +17,7 @@ use Kernel::System::VariableCheck qw(:all);
 
 our @ObjectDependencies = (
     'Kernel::Config',
+    'Kernel::Output::HTML::Layout',
     'Kernel::System::Cache',
     'Kernel::System::CheckItem',
     'Kernel::System::CustomerUser',
@@ -1097,6 +1099,7 @@ sub CertificateAdd {
 
     my $DBObject       = $Kernel::OM->Get('Kernel::System::DB');
     my $DateTimeObject = $Kernel::OM->Create('Kernel::System::DateTime');
+    my $LayoutObject   = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
 
     my $UserID = $Param{UserID} // 1;
 
@@ -1119,7 +1122,7 @@ sub CertificateAdd {
         );
         %Result = (
             Successful => 0,
-            Message    => 'Can\'t add invalid certificate!',
+            Message    => $LayoutObject->{LanguageObject}->Translate('Can\'t add invalid certificate!'),
         );
         return %Result;
     }
@@ -1135,7 +1138,7 @@ sub CertificateAdd {
         if ( $Attributes{Fingerprint} eq $CertResult->{Fingerprint} ) {
             %Result = (
                 Successful => 0,
-                Message    => 'Certificate already installed!',
+                Message    => $LayoutObject->{LanguageObject}->Translate('Certificate already installed!'),
             );
             return %Result;
         }
@@ -1159,7 +1162,7 @@ sub CertificateAdd {
             close($OUT);
             %Result = (
                 Successful => 1,
-                Message    => 'Certificate uploaded',
+                Message    => $LayoutObject->{LanguageObject}->Translate('Certificate uploaded'),
                 Filename   => "$Attributes{Hash}.$Count",
             );
 
@@ -1200,7 +1203,8 @@ sub CertificateAdd {
 
     %Result = (
         Successful => 0,
-        Message    => "No more available filenames for certificate hash:$Attributes{Hash}!",
+        Message    => $LayoutObject->{LanguageObject}
+            ->Translate( 'No more available filenames for certificate hash:%s!', $Attributes{Hash} ),
     );
     return %Result;
 }
@@ -1246,7 +1250,7 @@ sub CertificateGet {
 
 =head2 CertificateRemove()
 
-remove a local certificate
+remove a local certificate and its private key
 
     $CryptObject->CertificateRemove(
         Filename => $CertificateHash,
@@ -1262,7 +1266,8 @@ remove a local certificate
 sub CertificateRemove {
     my ( $Self, %Param ) = @_;
 
-    my $DBObject = $Kernel::OM->Get('Kernel::System::DB');
+    my $DBObject     = $Kernel::OM->Get('Kernel::System::DB');
+    my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
 
     # check needed stuff
     if ( !$Param{Filename} && !( $Param{Hash} && $Param{Fingerprint} ) ) {
@@ -1291,10 +1296,10 @@ sub CertificateRemove {
         );
     }
 
-    # private certificate shouldn't exists if certificate is deleted
-    # therefor if exists, first remove private certificate
-    # if private delete fails abort certificate removing
+    my $Message = $LayoutObject->{LanguageObject}->Translate('Certificate removed');
 
+    # Private key shouldn't exist without its certificate so remove private key first.
+    # If private key removing fails, abort certificate removing.
     my ($PrivateExists) = $Self->PrivateGet(
         Filename => $Param{Filename},
     );
@@ -1306,24 +1311,27 @@ sub CertificateRemove {
         if ( !$PrivateResults{Successful} ) {
             %Result = (
                 Successful => 0,
-                Message    => "Delete certificate aborted, $PrivateResults{Message}: $!!",
+                Message    => $LayoutObject->{LanguageObject}->Translate(
+                    'Error removing private key, certificate removing aborted: %s!',
+                    "$PrivateResults{Message}: $!"
+                ),
             );
             return %Result;
         }
+
+        $Message = $LayoutObject->{LanguageObject}->Translate('Certificate and its private key removed');
     }
 
-    my $Message = "Certificate successfully removed";
     my $Success = 1;
 
-    # remove certificate
+    # Remove certificate.
     my $Cert = unlink "$Self->{CertPath}/$Param{Filename}";
     if ( !$Cert ) {
-        $Message = "Impossible to remove certificate: $Self->{CertPath}/$Param{Filename}: $!!";
+        $Message
+            = $LayoutObject->{LanguageObject}
+            ->Translate( 'Error removing certificate, only its private key was removed: %s!',
+            "$Self->{CertPath}/$Param{Filename}: $!" );
         $Success = 0;
-    }
-
-    if ($PrivateExists) {
-        $Message .= ". Private certificate successfully deleted";
     }
 
     if ($Success) {
@@ -1714,6 +1722,7 @@ sub PrivateAdd {
 
     my $DBObject       = $Kernel::OM->Get('Kernel::System::DB');
     my $DateTimeObject = $Kernel::OM->Create('Kernel::System::DateTime');
+    my $LayoutObject   = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
 
     my $UserID = $Param{UserID} // 1;
 
@@ -1738,7 +1747,7 @@ sub PrivateAdd {
         );
         %Result = (
             Successful => 0,
-            Message    => 'No private key',
+            Message    => $LayoutObject->{LanguageObject}->Translate('No private key!'),
         );
         return;
     }
@@ -1748,22 +1757,28 @@ sub PrivateAdd {
     if ( !@Certificates ) {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'error',
-            Message  => "Need Certificate of Private Key first -$Attributes{Modulus})!",
+            Message =>
+                "Certificate for private key not found (upload it first) or invalid private key or invalid password: $Attributes{Modulus})!",
         );
         %Result = (
             Successful => 0,
-            Message    => "Need Certificate of Private Key first -$Attributes{Modulus})!",
+            Message    => $LayoutObject->{LanguageObject}->Translate(
+                'Certificate for private key not found (upload it first) or invalid private key or invalid password: %s!',
+                $Attributes{Modulus}
+            ),
         );
         return %Result;
     }
     elsif ( $#Certificates > 0 ) {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'error',
-            Message  => 'Multiple Certificates with the same Modulus, can\'t add Private Key!',
+            Message  => $LayoutObject->{LanguageObject}
+                ->Translate('Multiple certificates with the same modulus, can\'t add private key!'),
         );
         %Result = (
             Successful => 0,
-            Message    => 'Multiple Certificates with the same Modulus, can\'t add Private Key!',
+            Message    => $LayoutObject->{LanguageObject}
+                ->Translate('Multiple certificates with the same modulus, can\'t add private key!'),
         );
         return %Result;
     }
@@ -1783,7 +1798,7 @@ sub PrivateAdd {
             close $PassFH;
             %Result = (
                 Successful => 1,
-                Message    => 'Private Key uploaded!',
+                Message    => $LayoutObject->{LanguageObject}->Translate('Private key uploaded'),
                 Filename   => $Certificates[0]->{Filename},
             );
 
@@ -1819,7 +1834,7 @@ sub PrivateAdd {
             );
             %Result = (
                 Successful => 0,
-                Message    => "Can't write $File: $!!",
+                Message    => $LayoutObject->{LanguageObject}->Translate( 'Can\'t write %s: %s!', $File, $! ),
             );
             return %Result;
         }
@@ -1831,7 +1846,7 @@ sub PrivateAdd {
     );
     %Result = (
         Successful => 0,
-        Message    => 'Can\'t add invalid private key!',
+        Message    => $LayoutObject->{LanguageObject}->Translate('Can\'t add invalid private key!'),
     );
 
     return %Result;
@@ -1911,7 +1926,8 @@ remove private key
 sub PrivateRemove {
     my ( $Self, %Param ) = @_;
 
-    my $DBObject = $Kernel::OM->Get('Kernel::System::DB');
+    my $DBObject     = $Kernel::OM->Get('Kernel::System::DB');
+    my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
 
     # check needed stuff
     if ( !$Param{Filename} && !( $Param{Hash} && $Param{Modulus} ) ) {
@@ -1930,19 +1946,22 @@ sub PrivateRemove {
         );
         %Return = (
             Successful => 0,
-            Message    => "Filename not found for hash: $Param{Hash} in: $Self->{PrivatePath}, $!!",
+            Message    => $LayoutObject->{LanguageObject}
+                ->Translate( "Filename not found for hash: %s in: %s, %s!", $Param{Hash}, $Self->{PrivatePath}, $! ),
         );
         return %Return if !$Param{Filename};
     }
 
     my $SecretDelete = unlink "$Self->{PrivatePath}/$Param{Filename}.P";
 
-    # abort if secret is not deleted
+    # Abort if secret is not deleted.
     if ( !$SecretDelete ) {
         %Return = (
             Successful => 0,
-            Message =>
-                "Delete private aborted, not possible to delete Secret: $Self->{PrivatePath}/$Param{Filename}.P, $!!",
+            Message    => $LayoutObject->{LanguageObject}->Translate(
+                'Deleting private key aborted, not possible to delete its secret %s: %s!',
+                "$Self->{PrivatePath}/$Param{Filename}.P", $!
+            ),
         );
         return %Return;
     }
@@ -1966,7 +1985,7 @@ sub PrivateRemove {
 
         %Return = (
             Successful => 1,
-            Message    => 'Private key deleted!'
+            Message    => $LayoutObject->{LanguageObject}->Translate('Private key deleted'),
         );
 
         return if !$DBObject->Do(
@@ -1991,7 +2010,8 @@ sub PrivateRemove {
 
     %Return = (
         Successful => 0,
-        Message    => "Impossible to delete key $Param{Filename} $!!"
+        Message    => $LayoutObject->{LanguageObject}
+            ->Translate( 'Impossible to delete private key %s: %s!', $Param{Filename}, $! ),
     );
 
     return %Return;

--- a/var/httpd/htdocs/js/Core.Agent.Admin.SMIME.js
+++ b/var/httpd/htdocs/js/Core.Agent.Admin.SMIME.js
@@ -45,7 +45,7 @@ Core.Agent.Admin = Core.Agent.Admin || {};
 
         // Bind click function to remove button
         $('#SMIME a.TrashCan').on('click', function () {
-            if (window.confirm(Core.Language.Translate('Do you really want to delete this certificate?'))) {
+            if (window.confirm(Core.Language.Translate('Do you really want to delete this item?'))) {
                 return true;
             }
             return false;


### PR DESCRIPTION
## Proposed change

Deleting S/MIME leaf certificate generates errors like 
```
Delete private aborted, not possible to delete Secret: [...]P, No such file or directory!
```
because of redundant call to private key deleting function (cert removal routine removes priv key already).

UI messages generated by S/MIME operations are not translated and some of them are misleading.

This mod fixes problem with redundant delete op, adds translations and fixes some S/MIME messages.

## Type of change

- '1 - 🐞 bug 🐞'            - Bugfix (non-breaking change which fixes an issue)

## Additional information

Author-Change-Id: IB#1161112## Checklist

- [x] The code change is tested and works locally.(❗)
- [ ] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [x] Local ZnunyCodePolicy passed.(❕)
- [x] Local UnitTests / Selenium passed.(❕)
- [ ] GitHub workflow CI (UnitTests / Selenium) passed.(❗)
