### PR TITLE
Add SendmailModule::Timeout parameter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,3 @@
-# ?.?.? ????-??-??
- - 2025-05-28 Added parameter SendmailModule::Timeout to allow SMTP timeout configuration.
-
 # 6.5.1 2023-03-09
  - 2023-02-28 Added options tickets-created-before-date and tickets-created-before-days to console command Admin::Article::StorageSwitch.
  - 2023-02-28 Fixed encoding of postmaster filter name in AdminPostMasterFilter.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# ?.?.? ????-??-??
+ - 2025-05-28 Added parameter SendmailModule::Timeout to allow SMTP timeout configuration.
+
 # 6.5.1 2023-03-09
  - 2023-02-28 Added options tickets-created-before-date and tickets-created-before-days to console command Admin::Article::StorageSwitch.
  - 2023-02-28 Fixed encoding of postmaster filter name in AdminPostMasterFilter.

--- a/Kernel/Config/Defaults.pm
+++ b/Kernel/Config/Defaults.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2025 Informatyka Boguslawski sp. z o.o. sp.k., https://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -390,6 +391,7 @@ sub LoadDefaults {
 #    $Self->{'SendmailModule'} = 'Kernel::System::Email::SMTP';
 #    $Self->{'SendmailModule::Host'} = 'mail.example.com';
 #    $Self->{'SendmailModule::Port'} = '25';
+#    $Self->{'SendmailModule::Timeout'} = '30';
 #    $Self->{'SendmailModule::AuthUser'} = '';
 #    $Self->{'SendmailModule::AuthPassword'} = '';
 

--- a/Kernel/Config/Defaults.pm
+++ b/Kernel/Config/Defaults.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2025 Informatyka Boguslawski sp. z o.o. sp.k., https://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/Config/Files/XML/Framework.xml
+++ b/Kernel/Config/Files/XML/Framework.xml
@@ -716,6 +716,13 @@
             <Item ValueType="String" ValueRegex="^[0-9]{1,6}$">25</Item>
         </Value>
     </Setting>
+    <Setting Name="SendmailModule::Timeout" Required="0" Valid="0" ConfigLevel="200">
+        <Description Translatable="1">If any of the "SMTP" mechanisms was selected as SendmailModule, maximum time, in seconds, to wait for a response from the SMTP server (default: 30).</Description>
+        <Navigation>Core::Email</Navigation>
+        <Value>
+            <Item ValueType="String" ValueRegex="^[0-9]{1,6}$">30</Item>
+        </Value>
+    </Setting>
     <Setting Name="SendmailModule::AuthUser" Required="0" Valid="0" ConfigLevel="200">
         <Description Translatable="1">If any of the "SMTP" mechanisms was selected as SendmailModule, and authentication to the mail server is needed, an username must be specified.</Description>
         <Navigation>Core::Email</Navigation>

--- a/Kernel/System/Email/SMTP.pm
+++ b/Kernel/System/Email/SMTP.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2025 Informatyka Boguslawski sp. z o.o. sp.k., https://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -72,6 +73,7 @@ sub Check {
     $Self->{MailHost} = $ConfigObject->Get('SendmailModule::Host')
         || die "No SendmailModule::Host found in Kernel/Config.pm";
     $Self->{SMTPPort}              = $ConfigObject->Get('SendmailModule::Port');
+    $Self->{SMTPTimeout}           = $ConfigObject->Get('SendmailModule::Timeout');
     $Self->{User}                  = $ConfigObject->Get('SendmailModule::AuthUser');
     $Self->{Password}              = $ConfigObject->Get('SendmailModule::AuthPassword');
     $Self->{AuthenticationType}    = $ConfigObject->Get('SendmailModule::AuthenticationType') // 'password';
@@ -107,10 +109,11 @@ sub Check {
         # connect to mail server
         eval {
             $SMTP = $Self->_Connect(
-                MailHost  => $Self->{MailHost},
-                FQDN      => $Self->{FQDN},
-                SMTPPort  => $Self->{SMTPPort},
-                SMTPDebug => $Self->{SMTPDebug},
+                MailHost    => $Self->{MailHost},
+                FQDN        => $Self->{FQDN},
+                SMTPPort    => $Self->{SMTPPort},
+                SMTPTimeout => $Self->{SMTPTimeout},
+                SMTPDebug   => $Self->{SMTPDebug},
             );
             return 1;
         } || do {
@@ -470,6 +473,7 @@ sub _Connect {
 
     my $SMTPDefaultPort = $Self->_GetSMTPDefaultPort();
     my $SMTPPort        = $Param{SMTPPort} || $SMTPDefaultPort;
+    my $SMTPTimeout     = $Param{SMTPTimeout} || 30;
 
     # set up connection connection
     my $SMTP = Net::SMTP->new(
@@ -477,7 +481,7 @@ sub _Connect {
         Hello => $FQDN,
         Port  => $SMTPPort,
         %SSLOptions,
-        Timeout => 30,
+        Timeout => $SMTPTimeout,
         Debug   => $Param{SMTPDebug},
     );
 

--- a/Kernel/System/Email/SMTP.pm
+++ b/Kernel/System/Email/SMTP.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2025 Informatyka Boguslawski sp. z o.o. sp.k., https://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you


### PR DESCRIPTION
## Proposed change

Znuny uses [hardcoded SMTP communication timeout 30s](https://github.com/znuny/Znuny/blob/cef5ff170c29bd5f40f43b071f153f63195f758d/Kernel/System/Email/SMTP.pm#L480) that may be too short in some scenarios (i.e. when large SMTP message is scanned by antivirus software on slower hardware before accepting message). Znuny's timeout is shorter than [Net::SMTP default (120s)](https://perldoc.perl.org/Net::SMTP).

This mod adds `SendmailModule::Timeout` SysConfig parameter to allow one to set SMTP communication timeout. If not defined (default), 30s will be used for backward compatibility.

## Type of change
  What type of change does your PR introduce to Znuny?
  NOTE: Please add only one label with a starting '1 - ' to this PR!
  If your PR requires multiple labels to be applied, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster for the code review.

- '1 - 🚀 feature'           - New feature (which adds functionality to an existing integration)


## Additional information

Author-Change-Id: IB#1161463

## Checklist

- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [x] Local ZnunyCodePolicy passed.(❕)
- [x] Local UnitTests / Selenium passed.(❕)
- [ ] GitHub workflow CI (UnitTests / Selenium) passed.(❗)
