### PR TITLE
Add parameter SMIME::NoDefaultCA and remove unnecessary parameter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# ?.?.? ????-??-??
+ - 2025-06-06 Added parameter SMIME::NoDefaultCA to allow disable loading of default CA certificates on S/MIME verification.
+
 # 6.5.15 2025-04-30
  - 2025-04-24 Fixed bug - Setting the password does not reset preferences UserLoginFailed and UserLastPwChangeTime.
  - 2025-04-16 Updated Net::IMAP::Simple to latest version from GitHub. Thanks to @dandanpena. [PR#155](https://github.com/znuny/Znuny/pull/155)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,3 @@
-# ?.?.? ????-??-??
- - 2025-06-06 Added parameter SMIME::NoDefaultCA to allow disable loading of default CA certificates on S/MIME verification.
-
 # 6.5.15 2025-04-30
  - 2025-04-24 Fixed bug - Setting the password does not reset preferences UserLoginFailed and UserLastPwChangeTime.
  - 2025-04-16 Updated Net::IMAP::Simple to latest version from GitHub. Thanks to @dandanpena. [PR#155](https://github.com/znuny/Znuny/pull/155)

--- a/Kernel/Config/Defaults.pm
+++ b/Kernel/Config/Defaults.pm
@@ -1127,6 +1127,7 @@ sub LoadDefaults {
 
 #    $Self->{'SMIME::CertPath'} = '/etc/ssl/certs';
 #    $Self->{'SMIME::PrivatePath'} = '/etc/ssl/private';
+#    $Self->{'SMIME::NoDefaultCA'} = 0;
 
     # --------------------------------------------------- #
     # system permissions

--- a/Kernel/Config/Files/XML/Framework.xml
+++ b/Kernel/Config/Files/XML/Framework.xml
@@ -3095,6 +3095,13 @@
             <Item ValueType="Checkbox">0</Item>
         </Value>
     </Setting>
+    <Setting Name="SMIME::NoDefaultCA" Required="0" Valid="0">
+        <Description Translatable="1">When enabled, no default CA certificates on S/MIME verification will be used.</Description>
+        <Navigation>Core::Crypt::SMIME</Navigation>
+        <Value>
+            <Item ValueType="Checkbox">0</Item>
+        </Value>
+    </Setting>
     <Setting Name="NotificationSenderName" Required="1" Valid="1">
         <Description Translatable="1">Specifies the name that should be used by the application when sending notifications. The sender name is used to build the complete display name for the notification master (i.e. "OTRS Notifications" otrs@your.example.com).</Description>
         <Navigation>Core::Email</Navigation>

--- a/Kernel/System/Crypt/SMIME.pm
+++ b/Kernel/System/Crypt/SMIME.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2025 Informatyka Boguslawski sp. z o.o. sp.k., https://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/System/Crypt/SMIME.pm
+++ b/Kernel/System/Crypt/SMIME.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2025 Informatyka Boguslawski sp. z o.o. sp.k., https://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -541,8 +542,21 @@ sub Verify {
         $NoVerifyOption = '-noverify';
     }
 
-    my $Options = "smime -verify $NoVerifyOption -in $SignedFile -out $VerifiedFile -signer $SignerFile "
-        . "-CApath $Self->{CertPath} $CertificateOption $SignedFile";
+    # Don't use default CA certs on S/MIME verification if SMIME::NoDefaultCA is enabled.
+    # See also https://docs.openssl.org/master/man1/openssl-verification-options/#trusted-certificate-options
+    my $NoDefaultCAOptions = '';
+    if ( $ConfigObject->Get('SMIME::NoDefaultCA') ) {
+        $NoDefaultCAOptions = '-no-CAfile -no-CApath';
+        if ( $Self->{OpenSSLMajorVersion} >= 3 ) {
+
+            # Disable also default certificates store (option available in OpenSSL 3+).
+            $NoDefaultCAOptions = $NoDefaultCAOptions . ' -no-CAstore';
+        }
+    }
+
+    my $Options
+        = "smime -verify $NoVerifyOption $NoDefaultCAOptions -in $SignedFile -out $VerifiedFile -signer $SignerFile "
+        . "-CApath $Self->{CertPath} $CertificateOption";
 
     my @LogLines = qx{$Self->{Cmd} $Options 2>&1};
     for my $LogLine (@LogLines) {


### PR DESCRIPTION
## Proposed change

Znuny does not disable OS default CA certificate sources on S/MIME verification which may lead to different verification results in different environments with same certs in `SMIME::CertPath`. For example: signature not trusted in Debian 11 may be trusted after upgrade to Debian 12 where [default trust was modified](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=805646).

This mod adds `SMIME::NoDefaultCA` (disabled by default for backward compatibility) to allow one to skip default OS CAs on S/MIME verification (and use trust only CAs in `SMIME::CertPath` like in Debian 11).

This mod also removes unnecessary parameter from
`openssl smime -verify`  command.

## Type of change

- '1 - 🐞 bug 🐞'            - Bugfix (non-breaking change which fixes an issue)

## Additional information

Related: https://docs.openssl.org/master/man1/openssl-verification-options/#trusted-certificate-options
Author-Change-Id: IB#1161846

## Checklist

- [x] The code change is tested and works locally.(❗)
- [ ] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [x] Local ZnunyCodePolicy passed.(❕)
- [x] Local UnitTests / Selenium passed.(❕)
- [ ] GitHub workflow CI (UnitTests / Selenium) passed.(❗)
