### PR TITLE
Sector Nord AG: BugFix: Allow table row highlighting for even rows in all DataTables

### DIFF
--- a/var/httpd/htdocs/skins/Agent/default/css/Core.Table.css
+++ b/var/httpd/htdocs/skins/Agent/default/css/Core.Table.css
@@ -49,7 +49,8 @@ did not receive this file, see https://www.gnu.org/licenses/gpl-3.0.txt.
 .TableSmall tbody tr:hover td,
 .DataTable tbody tr:active td.Clickable,
 .TableSmall tbody tr:active td.Clickable,
-.DataTable tr:nth-child(even):hover td.Highlight {
+.DataTable tr:nth-child(even):hover td.Highlight,
+.DataTable tbody tr:nth-child(even):hover td:not(:first-child:last-child) {
     background: var(--primary-color-rgb);
 }
 


### PR DESCRIPTION
<!--
  You are amazing! 🚀
  Thanks for contributing to the Znuny community project!
  Please, DO NOT DELETE ANY TEXT from this template (unless instructed)!

### Licensing, copyright and credits

Znuny is an open fork of an existing software. So we have to respect the already given copyright of the original creators.

New files will be licensed using the AGPL Version 3. If you contribute code to the Znuny project you will get mentioned in the pull request incl. the commit, in CHANGES.md and in AUTHORS.md. We will not mention you in the file you provided or changed. Your work is highly appreciated and acknowledged but you contribute it to the project and your copyright will pass on to the fork itself.
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why this pull request should be accepted. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Tables with the `DataTable` class only highlight odd rows on hover, while even rows remain unchanged. This creates an inconsistent user experience compared to `TableSmall` tables, which correctly highlight both odd and even rows on hover.

The issue is caused by CSS specificity conflicts. The zebra striping rule for even rows has higher specificity than the hover rule, causing it to override the hover background on even rows.

**Current hover rule:**


```css
.DataTable tbody tr:hover td,
.TableSmall tbody tr:hover td,
.DataTable tbody tr:active td.Clickable,
.TableSmall tbody tr:active td.Clickable,
.DataTable tr:nth-child(even):hover td.Highlight {
    background: var(--primary-color-rgb);
}
```

**Conflicting zebra stripe rule**

```css
.DataTable tr:nth-child(even) td:not(:first-child:last-child) {
    background-color: var(--table-td-even-bg);
}
```


In order to fix this, a more specific selector can be added to ensure hover styling is applied as expected. 

**Updated hover rule:**

```css
.DataTable tbody tr:hover td,
.TableSmall tbody tr:hover td,
.DataTable tbody tr:active td.Clickable,
.TableSmall tbody tr:active td.Clickable,
.DataTable tr:nth-child(even):hover td.Highlight,
.DataTable tbody tr:nth-child(even):hover td:not(:first-child:last-child) {
    background: var(--primary-color-rgb);
}
```

## Type of change
<!---
  What type of change does your PR introduce to Znuny?
  NOTE: Please add only one label with a starting '1 - ' to this PR!
  If your PR requires multiple labels to be applied, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster for the code review.

- '1 - 🆙 dependency upgrade - Dependency upgrade (e.g. libraries)
- '1 - 🐞 bug 🐞'            - Bugfix (non-breaking change which fixes an issue)
- '1 - 💎 code quality'      - Code quality improvements to existing code or addition of unit tests
- '1 - 🚀 feature'           - New feature (which adds functionality to an existing integration)
- '1 - ...'

-->
1 - 🐞 bug 🐞


<!--
## Breaking change
  If your PR contains a breaking change, it is important
  to tell what breaks, how to make it work again and why it is necessary.
  This piece of text is published with the release notes, so it helps if you
  write it for the users, not the maintainer.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Additional information
<!--
  Details are important and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  Note: Remove this section if not needed.

  If a PR is related to an issue, please use the 'Linked issues' function on the sidebar.
-->
To replicate:

- Navigate to `AgentDashboard` and hover over one of the table's rows
  - Only odd rows will be highlighted on hover
- Navigate to `AgentTicketQueue` and hover over one of the table's rows
  - Both odd and even rows will be highlighted on hover

<!--
- This PR is related to PR: #
- ...
-->

## Checklist
<!--
  Put an 'x' in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  ❕ - nice to have
  ❗ - required before review
-->

- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [ ] Local ZnunyCodePolicy passed.(❕)
- [ ] Local UnitTests / Selenium passed.(❕)
- [ ] GitHub workflow CI (UnitTests / Selenium) passed.(❗)

<!--
  Thank you for contributing ❤

  Znuny @znuny/znuny
-->
