### PR TITLE
Disable Frontend::Module###AgentTicketToUnitTest

### DIFF
--- a/Kernel/Config/Files/XML/Znuny.xml
+++ b/Kernel/Config/Files/XML/Znuny.xml
@@ -323,7 +323,7 @@
             </Hash>
         </Value>
     </Setting>
-    <Setting Name="Frontend::Module###AgentTicketToUnitTest" Required="1" Valid="1">
+    <Setting Name="Frontend::Module###AgentTicketToUnitTest" Required="0" Valid="0">
         <Description Translatable="1">Frontend module registration for the agent interface.</Description>
         <Navigation>Frontend::Agent::ModuleRegistration</Navigation>
         <Value>


### PR DESCRIPTION
## Proposed change

Module `Frontend::Module###AgentTicketToUnitTest` should be optional and disabled by default
because it is not required for typical Znuny instance to run.

## Type of change
- '1 - 🐞 bug 🐞'            - Bugfix (non-breaking change which fixes an issue)

## Additional information

Author-Change-Id: IB#1162965

## Checklist
<!--
  Put an 'x' in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  ❕ - nice to have
  ❗ - required before review
-->

- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [x] Local ZnunyCodePolicy passed.(❕)
- [x] Local UnitTests / Selenium passed.(❕)
- [ ] GitHub workflow CI (UnitTests / Selenium) passed.(❗)
