### PR TITLE
Don't display links to actions if not accessible

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,3 @@
-# 6.5.19 ????-??-??
- - 2025-11-26 Fixed: Don't display links to AdminSystemConfiguration, AdminACL nor AdminMailAccount if not accessible.
-
 # 6.5.18 2025-09-24
  - 2025-09-22 Fixed: Fix for installer email setting checks lead to issues with sending emails.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# 6.5.19 ????-??-??
+ - 2025-11-26 Fixed: Don't display links to AdminSystemConfiguration, AdminACL nor AdminMailAccount if not accessible.
+
 # 6.5.18 2025-09-24
  - 2025-09-22 Fixed: Fix for installer email setting checks lead to issues with sending emails.
 

--- a/Kernel/Modules/AdminCustomerGroup.pm
+++ b/Kernel/Modules/AdminCustomerGroup.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2025 Informatyka Bogusławski sp. z o.o. sp.k., https://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -24,6 +25,11 @@ sub new {
     my $Self = {%Param};
     bless( $Self, $Type );
 
+    $Self->{AdminSystemConfigurationPermission} = $Kernel::OM->Get('Kernel::Output::HTML::Layout')->Permission(
+        Action => 'AdminSystemConfiguration',
+        Type   => 'rw',
+    );
+
     return $Self;
 }
 
@@ -32,6 +38,8 @@ sub Run {
 
     my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
     my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+
+    $Param{AdminSystemConfigurationPermission} = $Self->{AdminSystemConfigurationPermission};
 
     # ------------------------------------------------------------ #
     # check if feature is active
@@ -371,6 +379,8 @@ sub _Change {
     my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
     my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
 
+    $Param{AdminSystemConfigurationPermission} = $Self->{AdminSystemConfigurationPermission};
+
     my %Data        = %{ $Param{Data} };
     my $Type        = $Param{Type} || 'Customer';
     my $NeType      = $Type eq 'Group' ? 'Customer' : 'Group';
@@ -430,7 +440,12 @@ sub _Change {
     else {
 
         # output config shortcut to CustomerAlwaysGroups
-        $LayoutObject->Block( Name => 'AlwaysGroupsConfig' );
+        $LayoutObject->Block(
+            Name => 'AlwaysGroupsConfig',
+            Data => {
+                %Param,
+            },
+        );
 
         $LayoutObject->Block( Name => 'Filter' );
     }
@@ -606,6 +621,8 @@ sub _Overview {
     my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
     my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
 
+    $Param{AdminSystemConfigurationPermission} = $Self->{AdminSystemConfigurationPermission};
+
     my $CustomerCount   = $Param{CustomerCount};
     my @CustomerKeyList = @{ $Param{CustomerKeyList} };
     my %CustomerData    = %{ $Param{CustomerData} };
@@ -628,7 +645,12 @@ sub _Overview {
     );
 
     # Output config shutcut to CustomerAlwaysGroups
-    $LayoutObject->Block( Name => 'AlwaysGroupsConfig' );
+    $LayoutObject->Block(
+        Name => 'AlwaysGroupsConfig',
+        Data => {
+            %Param,
+        },
+    );
 
     # output filter and default block
     $LayoutObject->Block(
@@ -743,6 +765,8 @@ sub _Disabled {
     my ( $Self, %Param ) = @_;
 
     my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
+
+    $Param{AdminSystemConfigurationPermission} = $Self->{AdminSystemConfigurationPermission};
 
     $LayoutObject->Block(
         Name => 'Overview',

--- a/Kernel/Modules/AdminCustomerGroup.pm
+++ b/Kernel/Modules/AdminCustomerGroup.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2025 Informatyka Bogusławski sp. z o.o. sp.k., https://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/Modules/AdminCustomerUserGroup.pm
+++ b/Kernel/Modules/AdminCustomerUserGroup.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2025 Informatyka Bogusławski sp. z o.o. sp.k., https://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -23,6 +24,11 @@ sub new {
     my $Self = {%Param};
     bless( $Self, $Type );
 
+    $Self->{AdminSystemConfigurationPermission} = $Kernel::OM->Get('Kernel::Output::HTML::Layout')->Permission(
+        Action => 'AdminSystemConfiguration',
+        Type   => 'rw',
+    );
+
     return $Self;
 }
 
@@ -31,6 +37,8 @@ sub Run {
 
     my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
     my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
+
+    $Param{AdminSystemConfigurationPermission} = $Self->{AdminSystemConfigurationPermission};
 
     # ------------------------------------------------------------ #
     # check if feature is active
@@ -347,6 +355,8 @@ sub _Change {
     my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
     my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
 
+    $Param{AdminSystemConfigurationPermission} = $Self->{AdminSystemConfigurationPermission};
+
     my %Data        = %{ $Param{Data} };
     my $Type        = $Param{Type} || 'CustomerUser';
     my $NeType      = $Type eq 'Group' ? 'CustomerUser' : 'Group';
@@ -404,7 +414,12 @@ sub _Change {
     else {
 
         # output config shortcut to CustomerAlwaysGroups
-        $LayoutObject->Block( Name => 'AlwaysGroupsConfig' );
+        $LayoutObject->Block(
+            Name => 'AlwaysGroupsConfig',
+            Data => {
+                %Param,
+            },
+        );
 
         $LayoutObject->Block( Name => 'Filter' );
     }
@@ -555,6 +570,8 @@ sub _Overview {
     my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
     my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
 
+    $Param{AdminSystemConfigurationPermission} = $Self->{AdminSystemConfigurationPermission};
+
     my $CustomerUserCount   = $Param{CustomerUserCount};
     my @CustomerUserKeyList = @{ $Param{CustomerUserKeyList} };
     my %CustomerUserData    = %{ $Param{CustomerUserData} };
@@ -579,7 +596,12 @@ sub _Overview {
     );
 
     # Output config shutcut to CustomerAlwaysGroups
-    $LayoutObject->Block( Name => 'AlwaysGroupsConfig' );
+    $LayoutObject->Block(
+        Name => 'AlwaysGroupsConfig',
+        Data => {
+            %Param,
+        },
+    );
 
     # output filter and default block
     $LayoutObject->Block(
@@ -694,6 +716,8 @@ sub _Disabled {
     my ( $Self, %Param ) = @_;
 
     my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
+
+    $Param{AdminSystemConfigurationPermission} = $Self->{AdminSystemConfigurationPermission};
 
     $LayoutObject->Block(
         Name => 'Overview',

--- a/Kernel/Modules/AdminCustomerUserGroup.pm
+++ b/Kernel/Modules/AdminCustomerUserGroup.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2025 Informatyka Bogusławski sp. z o.o. sp.k., https://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/Modules/AdminMailAccount.pm
+++ b/Kernel/Modules/AdminMailAccount.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2025 Informatyka Bogusławski sp. z o.o. sp.k., https://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/Modules/AdminMailAccount.pm
+++ b/Kernel/Modules/AdminMailAccount.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2025 Informatyka Bogusławski sp. z o.o. sp.k., https://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -23,6 +24,11 @@ sub new {
     my $Self = {%Param};
     bless( $Self, $Type );
 
+    $Self->{AdminSystemConfigurationPermission} = $Kernel::OM->Get('Kernel::Output::HTML::Layout')->Permission(
+        Action => 'AdminSystemConfiguration',
+        Type   => 'rw',
+    );
+
     return $Self;
 }
 
@@ -32,6 +38,8 @@ sub Run {
     my $LayoutObject      = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
     my $ParamObject       = $Kernel::OM->Get('Kernel::System::Web::Request');
     my $MailAccountObject = $Kernel::OM->Get('Kernel::System::MailAccount');
+
+    $Param{AdminSystemConfigurationPermission} = $Self->{AdminSystemConfigurationPermission};
 
     my %GetParam = ();
     my @Params   = (
@@ -368,6 +376,8 @@ sub _Overview {
     my $LayoutObject      = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
     my $MailAccountObject = $Kernel::OM->Get('Kernel::System::MailAccount');
 
+    $Param{AdminSystemConfigurationPermission} = $Self->{AdminSystemConfigurationPermission};
+
     my %Backend = $MailAccountObject->MailAccountBackendList();
 
     $LayoutObject->Block(
@@ -424,6 +434,8 @@ sub _MaskUpdateMailAccount {
     my ( $Self, %Param ) = @_;
 
     my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
+
+    $Param{AdminSystemConfigurationPermission} = $Self->{AdminSystemConfigurationPermission};
 
     # get valid list
     my %ValidList        = $Kernel::OM->Get('Kernel::System::Valid')->ValidList();
@@ -503,6 +515,8 @@ sub _MaskAddMailAccount {
     my ( $Self, %Param ) = @_;
 
     my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
+
+    $Param{AdminSystemConfigurationPermission} = $Self->{AdminSystemConfigurationPermission};
 
     # get valid list
     my %ValidList        = $Kernel::OM->Get('Kernel::System::Valid')->ValidList();

--- a/Kernel/Modules/AdminPriority.pm
+++ b/Kernel/Modules/AdminPriority.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2025 Informatyka Bogusławski sp. z o.o. sp.k., https://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/Modules/AdminPriority.pm
+++ b/Kernel/Modules/AdminPriority.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2025 Informatyka Bogusławski sp. z o.o. sp.k., https://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -24,6 +25,11 @@ sub new {
     my $Self = {%Param};
     bless( $Self, $Type );
 
+    $Self->{AdminSystemConfigurationPermission} = $Kernel::OM->Get('Kernel::Output::HTML::Layout')->Permission(
+        Action => 'AdminSystemConfiguration',
+        Type   => 'rw',
+    );
+
     return $Self;
 }
 
@@ -40,6 +46,8 @@ sub Run {
     my $LayoutObject   = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
     my $ParamObject    = $Kernel::OM->Get('Kernel::System::Web::Request');
     my $PriorityObject = $Kernel::OM->Get('Kernel::System::Priority');
+
+    $Param{AdminSystemConfigurationPermission} = $Self->{AdminSystemConfigurationPermission};
 
     # ------------------------------------------------------------ #
     # change
@@ -308,6 +316,8 @@ sub _Edit {
 
     my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
 
+    $Param{AdminSystemConfigurationPermission} = $Self->{AdminSystemConfigurationPermission};
+
     $LayoutObject->Block(
         Name => 'Overview',
         Data => \%Param,
@@ -403,6 +413,8 @@ sub _Overview {
     my ( $Self, %Param ) = @_;
 
     my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
+
+    $Param{AdminSystemConfigurationPermission} = $Self->{AdminSystemConfigurationPermission};
 
     $LayoutObject->Block(
         Name => 'Overview',

--- a/Kernel/Modules/AdminProcessManagement.pm
+++ b/Kernel/Modules/AdminProcessManagement.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2025 Informatyka Bogusławski sp. z o.o. sp.k., https://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -24,6 +25,16 @@ sub new {
 
     my $Self = {%Param};
     bless( $Self, $Type );
+
+    $Self->{AdminACLPermission} = $Kernel::OM->Get('Kernel::Output::HTML::Layout')->Permission(
+        Action => 'AdminACL',
+        Type   => 'rw',
+    );
+
+    $Self->{AdminSystemConfigurationPermission} = $Kernel::OM->Get('Kernel::Output::HTML::Layout')->Permission(
+        Action => 'AdminSystemConfiguration',
+        Type   => 'rw',
+    );
 
     return $Self;
 }
@@ -68,6 +79,9 @@ sub Run {
     my $ProcessObject = $Kernel::OM->Get('Kernel::System::ProcessManagement::DB::Process');
     my $StateObject   = $Kernel::OM->Get('Kernel::System::ProcessManagement::DB::Process::State');
     my $ConfigObject  = $Kernel::OM->Get('Kernel::Config');
+
+    $Param{AdminACLPermission}                 = $Self->{AdminACLPermission};
+    $Param{AdminSystemConfigurationPermission} = $Self->{AdminSystemConfigurationPermission};
 
     # ------------------------------------------------------------ #
     # ProcessImport
@@ -1599,6 +1613,9 @@ sub _ShowOverview {
     my ( $Self, %Param ) = @_;
 
     my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
+
+    $Param{AdminACLPermission}                 = $Self->{AdminACLPermission};
+    $Param{AdminSystemConfigurationPermission} = $Self->{AdminSystemConfigurationPermission};
 
     my $Output = $LayoutObject->Header();
     $Output .= $LayoutObject->NavigationBar();

--- a/Kernel/Modules/AdminProcessManagement.pm
+++ b/Kernel/Modules/AdminProcessManagement.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2025 Informatyka Bogusławski sp. z o.o. sp.k., https://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/Modules/AdminQueue.pm
+++ b/Kernel/Modules/AdminQueue.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2025 Informatyka Bogusławski sp. z o.o. sp.k., https://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/Modules/AdminQueue.pm
+++ b/Kernel/Modules/AdminQueue.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2025 Informatyka Bogusławski sp. z o.o. sp.k., https://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -24,6 +25,16 @@ sub new {
     # allocate new hash for object
     my $Self = {%Param};
     bless( $Self, $Type );
+
+    $Self->{AdminMailAccountPermission} = $Kernel::OM->Get('Kernel::Output::HTML::Layout')->Permission(
+        Action => 'AdminMailAccount',
+        Type   => 'rw',
+    );
+
+    $Self->{AdminSystemConfigurationPermission} = $Kernel::OM->Get('Kernel::Output::HTML::Layout')->Permission(
+        Action => 'AdminSystemConfiguration',
+        Type   => 'rw',
+    );
 
     return $Self;
 }
@@ -110,6 +121,9 @@ sub Run {
     my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
     my $MainObject   = $Kernel::OM->Get('Kernel::System::Main');
     my $Notification = $ParamObject->GetParam( Param => 'Notification' ) || '';
+
+    $Param{AdminMailAccountPermission}         = $Self->{AdminMailAccountPermission};
+    $Param{AdminSystemConfigurationPermission} = $Self->{AdminSystemConfigurationPermission};
 
     # ------------------------------------------------------------ #
     # change
@@ -577,6 +591,9 @@ sub _Edit {
 
     my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
 
+    $Param{AdminMailAccountPermission}         = $Self->{AdminMailAccountPermission};
+    $Param{AdminSystemConfigurationPermission} = $Self->{AdminSystemConfigurationPermission};
+
     $LayoutObject->Block(
         Name => 'Overview',
         Data => \%Param,
@@ -948,6 +965,9 @@ sub _Overview {
     my ( $Self, %Param ) = @_;
 
     my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
+
+    $Param{AdminMailAccountPermission}         = $Self->{AdminMailAccountPermission};
+    $Param{AdminSystemConfigurationPermission} = $Self->{AdminSystemConfigurationPermission};
 
     $LayoutObject->Block(
         Name => 'Overview',

--- a/Kernel/Modules/AdminSLA.pm
+++ b/Kernel/Modules/AdminSLA.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2025 Informatyka Bogusławski sp. z o.o. sp.k., https://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -23,6 +24,11 @@ sub new {
 
     $Self->{IsITSMInstalled} = $Kernel::OM->Get('Kernel::System::Util')->IsITSMInstalled();
 
+    $Self->{AdminSystemConfigurationPermission} = $Kernel::OM->Get('Kernel::Output::HTML::Layout')->Permission(
+        Action => 'AdminSystemConfiguration',
+        Type   => 'rw',
+    );
+
     return $Self;
 }
 
@@ -35,7 +41,8 @@ sub Run {
     my $SLAObject    = $Kernel::OM->Get('Kernel::System::SLA');
     my %Error        = ();
 
-    $Param{IsITSMInstalled} = $Self->{IsITSMInstalled};
+    $Param{IsITSMInstalled}                    = $Self->{IsITSMInstalled};
+    $Param{AdminSystemConfigurationPermission} = $Self->{AdminSystemConfigurationPermission};
 
     # ------------------------------------------------------------ #
     # sla edit
@@ -338,7 +345,8 @@ sub _MaskNew {
 
     my $ParamObject = $Kernel::OM->Get('Kernel::System::Web::Request');
 
-    $Param{IsITSMInstalled} = $Self->{IsITSMInstalled};
+    $Param{IsITSMInstalled}                    = $Self->{IsITSMInstalled};
+    $Param{AdminSystemConfigurationPermission} = $Self->{AdminSystemConfigurationPermission};
 
     # get params
     my %SLAData;

--- a/Kernel/Modules/AdminSLA.pm
+++ b/Kernel/Modules/AdminSLA.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2025 Informatyka Bogusławski sp. z o.o. sp.k., https://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/Modules/AdminService.pm
+++ b/Kernel/Modules/AdminService.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2025 Informatyka Bogusławski sp. z o.o. sp.k., https://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -25,6 +26,11 @@ sub new {
 
     $Self->{IsITSMInstalled} = $Kernel::OM->Get('Kernel::System::Util')->IsITSMInstalled();
 
+    $Self->{AdminSystemConfigurationPermission} = $Kernel::OM->Get('Kernel::Output::HTML::Layout')->Permission(
+        Action => 'AdminSystemConfiguration',
+        Type   => 'rw',
+    );
+
     return $Self;
 }
 
@@ -35,7 +41,8 @@ sub Run {
     my $ConfigObject  = $Kernel::OM->Get('Kernel::Config');
     my $ServiceObject = $Kernel::OM->Get('Kernel::System::Service');
 
-    $Param{IsITSMInstalled} = $Self->{IsITSMInstalled};
+    $Param{IsITSMInstalled}                    = $Self->{IsITSMInstalled};
+    $Param{AdminSystemConfigurationPermission} = $Self->{AdminSystemConfigurationPermission};
 
     if ( $Self->{IsITSMInstalled} ) {
         my $DynamicFieldObject = $Kernel::OM->Get('Kernel::System::DynamicField');
@@ -335,7 +342,8 @@ sub _MaskNew {
     my $ServiceObject = $Kernel::OM->Get('Kernel::System::Service');
     my %ServiceData;
 
-    $Param{IsITSMInstalled} = $Self->{IsITSMInstalled};
+    $Param{IsITSMInstalled}                    = $Self->{IsITSMInstalled};
+    $Param{AdminSystemConfigurationPermission} = $Self->{AdminSystemConfigurationPermission};
 
     # get params
     $ServiceData{ServiceID} = $Kernel::OM->Get('Kernel::System::Web::Request')->GetParam( Param => "ServiceID" );

--- a/Kernel/Modules/AdminService.pm
+++ b/Kernel/Modules/AdminService.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2025 Informatyka Bogusławski sp. z o.o. sp.k., https://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/Modules/AdminState.pm
+++ b/Kernel/Modules/AdminState.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2025 Informatyka Bogusławski sp. z o.o. sp.k., https://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -24,6 +25,11 @@ sub new {
     my $Self = {%Param};
     bless( $Self, $Type );
 
+    $Self->{AdminSystemConfigurationPermission} = $Kernel::OM->Get('Kernel::Output::HTML::Layout')->Permission(
+        Action => 'AdminSystemConfiguration',
+        Type   => 'rw',
+    );
+
     return $Self;
 }
 
@@ -40,6 +46,8 @@ sub Run {
     my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
     my $ParamObject  = $Kernel::OM->Get('Kernel::System::Web::Request');
     my $StateObject  = $Kernel::OM->Get('Kernel::System::State');
+
+    $Param{AdminSystemConfigurationPermission} = $Self->{AdminSystemConfigurationPermission};
 
     # ------------------------------------------------------------ #
     # change
@@ -327,6 +335,8 @@ sub _Edit {
     my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
     my $StateObject  = $Kernel::OM->Get('Kernel::System::State');
 
+    $Param{AdminSystemConfigurationPermission} = $Self->{AdminSystemConfigurationPermission};
+
     $LayoutObject->Block(
         Name => 'Overview',
         Data => \%Param,
@@ -425,6 +435,8 @@ sub _Overview {
     my ( $Self, %Param ) = @_;
 
     my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
+
+    $Param{AdminSystemConfigurationPermission} = $Self->{AdminSystemConfigurationPermission};
 
     $LayoutObject->Block(
         Name => 'Overview',

--- a/Kernel/Modules/AdminState.pm
+++ b/Kernel/Modules/AdminState.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2025 Informatyka Bogusławski sp. z o.o. sp.k., https://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/Modules/AdminType.pm
+++ b/Kernel/Modules/AdminType.pm
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2025 Informatyka Bogusławski sp. z o.o. sp.k., https://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -22,6 +23,11 @@ sub new {
 
     my $Self = {%Param};
     bless( $Self, $Type );
+
+    $Self->{AdminSystemConfigurationPermission} = $Kernel::OM->Get('Kernel::Output::HTML::Layout')->Permission(
+        Action => 'AdminSystemConfiguration',
+        Type   => 'rw',
+    );
 
     return $Self;
 }
@@ -51,6 +57,8 @@ sub Run {
                 . 'Action=AdminSystemConfiguration;Subaction=View;Setting=Ticket%3A%3AType',
         );
     }
+
+    $Param{AdminSystemConfigurationPermission} = $Self->{AdminSystemConfigurationPermission};
 
     # ------------------------------------------------------------ #
     # change
@@ -358,6 +366,8 @@ sub _Edit {
 
     my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
 
+    $Param{AdminSystemConfigurationPermission} = $Self->{AdminSystemConfigurationPermission};
+
     $LayoutObject->Block(
         Name => 'Overview',
         Data => \%Param,
@@ -457,6 +467,8 @@ sub _Overview {
     my ( $Self, %Param ) = @_;
 
     my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
+
+    $Param{AdminSystemConfigurationPermission} = $Self->{AdminSystemConfigurationPermission};
 
     $LayoutObject->Block(
         Name => 'Overview',

--- a/Kernel/Modules/AdminType.pm
+++ b/Kernel/Modules/AdminType.pm
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2025 Informatyka Bogusławski sp. z o.o. sp.k., https://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/Output/HTML/Templates/Standard/AdminCustomerGroup.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminCustomerGroup.tt
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2025 Informatyka Bogusławski sp. z o.o. sp.k., https://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -90,6 +91,7 @@
                     </li>
 [% RenderBlockEnd("Search") %]
 [% RenderBlockStart("AlwaysGroupsConfig") %]
+                    [% IF Data.AdminSystemConfigurationPermission %]
                     <li>
                         <a href="[% Env("Baselink") %]Action=AdminSystemConfiguration;Subaction=View;Setting=CustomerGroupCompanyAlwaysGroups" class="CallForAction Fullsize Center"><span><i class="fa fa-edit"></i>[% Translate("Edit Customer Default Groups") | html %]</span></a>
                         <p class="FieldExplanation">
@@ -97,6 +99,7 @@
                             [% Translate("You can manage these groups via the configuration setting \"CustomerGroupCompanyAlwaysGroups\".") | html %]
                         </p>
                     </li>
+                    [% END %]
 
 [% RenderBlockEnd("AlwaysGroupsConfig") %]
                 </ul>

--- a/Kernel/Output/HTML/Templates/Standard/AdminCustomerGroup.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminCustomerGroup.tt
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2025 Informatyka Bogusławski sp. z o.o. sp.k., https://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/Output/HTML/Templates/Standard/AdminCustomerUserGroup.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminCustomerUserGroup.tt
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2025 Informatyka Bogusławski sp. z o.o. sp.k., https://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -91,6 +92,7 @@
                     </li>
 [% RenderBlockEnd("Search") %]
 [% RenderBlockStart("AlwaysGroupsConfig") %]
+                    [% IF Data.AdminSystemConfigurationPermission %]
                     <li>
                         <a href="[% Env("Baselink") %]Action=AdminSystemConfiguration;Subaction=View;Setting=CustomerGroupAlwaysGroups" class="CallForAction Fullsize Center"><span><i class="fa fa-edit"></i>[% Translate("Edit Customer User Default Groups") | html %]</span></a>
                         <p class="FieldExplanation">
@@ -98,6 +100,7 @@
                             [% Translate("You can manage these groups via the configuration setting \"CustomerGroupAlwaysGroups\".") | html %]
                         </p>
                     </li>
+                    [% END %]
 
 [% RenderBlockEnd("AlwaysGroupsConfig") %]
                 </ul>

--- a/Kernel/Output/HTML/Templates/Standard/AdminCustomerUserGroup.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminCustomerUserGroup.tt
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2025 Informatyka Bogusławski sp. z o.o. sp.k., https://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/Output/HTML/Templates/Standard/AdminMailAccount.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminMailAccount.tt
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2025 Informatyka Bogusławski sp. z o.o. sp.k., https://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -74,8 +75,13 @@
                     [% Translate("If your account is marked as trusted, the X-OTRS headers already existing at arrival time (for priority etc.) will be kept and used, for example in PostMaster filters.") | html %]
                 </p>
                 <p class="FieldExplanation">
+                    [% IF Data.AdminSystemConfigurationPermission %]
                     [% Translate("Outgoing email can be configured via the Sendmail* settings in %s.",
                     '<a href="?Action=AdminSystemConfigurationGroup;RootNavigation=Core::Email">' _ Translate("System Configuration") _ '</a>') %]
+                    [% ELSE %]
+                    [% Translate("Outgoing email can be configured via the Sendmail* settings in %s.",
+                    Translate("System Configuration")) %]
+                    [% END %]
             </div>
         </div>
         <div class='WidgetSimple'>

--- a/Kernel/Output/HTML/Templates/Standard/AdminMailAccount.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminMailAccount.tt
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2025 Informatyka Bogusławski sp. z o.o. sp.k., https://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/Output/HTML/Templates/Standard/AdminPriority.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminPriority.tt
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2025 Informatyka Bogusławski sp. z o.o. sp.k., https://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -72,6 +73,7 @@
             </div>
             <div class='Content'>
                 <ul class='ActionList SpacingTop'>
+                    [% IF Data.AdminSystemConfigurationPermission %]
                     <li>
                         <a href='[% Env("Baselink") %]Action=AdminSystemConfiguration;Subaction=Search;Search=%23%23%23Priority' class='CallForAction Fullsize Center'>
                             <span>
@@ -79,6 +81,7 @@
                             </span>
                         </a>
                     </li>
+                    [% END %]
                 </ul>
             </div>
         </div>

--- a/Kernel/Output/HTML/Templates/Standard/AdminPriority.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminPriority.tt
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2025 Informatyka Bogusławski sp. z o.o. sp.k., https://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/Output/HTML/Templates/Standard/AdminProcessManagement.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminProcessManagement.tt
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2025 Informatyka Bogusławski sp. z o.o. sp.k., https://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -124,6 +125,7 @@
             </div>
             <div class='Content'>
                 <ul class='ActionList SpacingTop'>
+                    [% IF Data.AdminACLPermission %]
                     <li>
                         <a href='[% Env("Baselink") %]Action=AdminACL' class='CallForAction Fullsize Center'>
                             <span>
@@ -131,6 +133,7 @@
                             </span>
                         </a>
                     </li>
+                    [% END %]
                     <li>
                         <a href='[% Env("Baselink") %]Action=AdminDynamicField' class='CallForAction Fullsize Center'>
                             <span>
@@ -145,6 +148,7 @@
                             </span>
                         </a>
                     </li>
+                    [% IF Data.AdminSystemConfigurationPermission %]
                     <li>
                         <a href="[% Env("Baselink") %]Action=AdminSystemConfiguration;Subaction=View;Setting=Ticket%3A%3AFrontend%3A%3AAgentTicketZoom%23%23%23ProcessWidgetDynamicFieldGroups;ChallengeToken=KDtGaGclmu2ObuGcZSWayxkbvL5rOa5p;" class="CallForAction Fullsize Center">
                             <span>
@@ -152,6 +156,7 @@
                             </span>
                         </a>
                     </li>
+                    [% END %]
                 </ul>
             </div>
         </div>

--- a/Kernel/Output/HTML/Templates/Standard/AdminProcessManagement.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminProcessManagement.tt
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2025 Informatyka Bogusławski sp. z o.o. sp.k., https://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/Output/HTML/Templates/Standard/AdminQueue.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminQueue.tt
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2025 Informatyka Bogusławski sp. z o.o. sp.k., https://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -87,6 +88,7 @@
                             </span>
                         </a>
                     </li>
+                    [% IF Data.AdminMailAccountPermission %]
                     <li>
                         <a href='[% Env("Baselink") %]Action=AdminMailAccount' class='CallForAction Fullsize Center'>
                             <span>
@@ -94,6 +96,7 @@
                             </span>
                         </a>
                     </li>
+                    [% END %]
                     <li>
                         <a href='[% Env("Baselink") %]Action=AdminSalutation' class='CallForAction Fullsize Center'>
                             <span>
@@ -122,6 +125,7 @@
                             </span>
                         </a>
                     </li>
+                    [% IF Data.AdminSystemConfigurationPermission %]
                     <li>
                         <a href='[% Env("Baselink") %]Action=AdminSystemConfiguration;Subaction=Search;Search=TimeWorkingHours' class='CallForAction Fullsize Center'>
                             <span>
@@ -136,6 +140,7 @@
                             </span>
                         </a>
                     </li>
+                    [% END %]
                 </ul>
             </div>
         </div>

--- a/Kernel/Output/HTML/Templates/Standard/AdminQueue.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminQueue.tt
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2025 Informatyka Bogusławski sp. z o.o. sp.k., https://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/Output/HTML/Templates/Standard/AdminSLA.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminSLA.tt
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2025 Informatyka Bogusławski sp. z o.o. sp.k., https://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -80,6 +81,7 @@
                             </span>
                         </a>
                     </li>
+                    [% IF Data.AdminSystemConfigurationPermission %]
                     <li>
                         <a href='[% Env("Baselink") %]Action=AdminSystemConfiguration;Subaction=Search;Search=%23%23%23SLA' class='CallForAction Fullsize Center'>
                             <span>
@@ -94,6 +96,7 @@
                             </span>
                         </a>
                     </li>
+                    [% END %]
                 </ul>
             </div>
         </div>

--- a/Kernel/Output/HTML/Templates/Standard/AdminSLA.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminSLA.tt
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2025 Informatyka Bogusławski sp. z o.o. sp.k., https://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/Output/HTML/Templates/Standard/AdminService.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminService.tt
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2025 Informatyka Bogusławski sp. z o.o. sp.k., https://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -85,6 +86,7 @@
                             </span>
                         </a>
                     </li>
+                    [% IF Data.AdminSystemConfigurationPermission %]
                     <li>
                         <a href='[% Env("Baselink") %]Action=AdminSystemConfiguration;Subaction=Search;Search=%23%23%23Service' class='CallForAction Fullsize Center'>
                             <span>
@@ -92,6 +94,7 @@
                             </span>
                         </a>
                     </li>
+                    [% END %]
                 </ul>
             </div>
         </div>

--- a/Kernel/Output/HTML/Templates/Standard/AdminService.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminService.tt
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2025 Informatyka Bogusławski sp. z o.o. sp.k., https://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/Output/HTML/Templates/Standard/AdminState.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminState.tt
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2025 Informatyka Bogusławski sp. z o.o. sp.k., https://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/Output/HTML/Templates/Standard/AdminState.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminState.tt
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2025 Informatyka Bogusławski sp. z o.o. sp.k., https://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -83,6 +84,7 @@
             </div>
             <div class='Content'>
                 <ul class='ActionList SpacingTop'>
+                    [% IF Data.AdminSystemConfigurationPermission %]
                     <li>
                         <a href='[% Env("Baselink") %]Action=AdminSystemConfiguration;Subaction=Search;Search=%23%23%23State' class='CallForAction Fullsize Center'>
                             <span>
@@ -97,6 +99,7 @@
                             </span>
                         </a>
                     </li>
+                    [% END %]
                 </ul>
             </div>
         </div>

--- a/Kernel/Output/HTML/Templates/Standard/AdminType.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminType.tt
@@ -1,7 +1,6 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
-# Copyright (C) 2025 Informatyka Bogusławski sp. z o.o. sp.k., https://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you

--- a/Kernel/Output/HTML/Templates/Standard/AdminType.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminType.tt
@@ -1,6 +1,7 @@
 # --
 # Copyright (C) 2001-2021 OTRS AG, https://otrs.com/
 # Copyright (C) 2021 Znuny GmbH, https://znuny.org/
+# Copyright (C) 2025 Informatyka Bogusławski sp. z o.o. sp.k., https://www.ib.pl/
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (GPL). If you
@@ -71,6 +72,7 @@
             </div>
             <div class='Content'>
                 <ul class='ActionList SpacingTop'>
+                    [% IF Data.AdminSystemConfigurationPermission %]
                     <li>
                         <a href='[% Env("Baselink") %]Action=AdminSystemConfiguration;Subaction=Search;Search=%23%23%23TicketType' class='CallForAction Fullsize Center'>
                             <span>
@@ -78,6 +80,7 @@
                             </span>
                         </a>
                     </li>
+                    [% END %]
                 </ul>
             </div>
         </div>


### PR DESCRIPTION
## Proposed change

Remove links to `AdminSystemConfiguration`, `AdminACL` and `AdminMailAccount` actions not available to user due to permissions or disabled module.

## Type of change
- '1 - 🐞 bug 🐞'            - Bugfix (non-breaking change which fixes an issue)

## Additional information
Author-Change-Id: IB#1167090

## Checklist
- [x ] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [x] Local ZnunyCodePolicy passed.(❕)
- [x] Local UnitTests / Selenium passed.(❕)
- [ ] GitHub workflow CI (UnitTests / Selenium) passed.(❗)
