### PR TITLE
Efflux: Process Management: Enable transition chaining (A→B→C without refresh)

### DIFF
--- a/Kernel/System/Ticket/Event/TicketProcessTransitions.pm
+++ b/Kernel/System/Ticket/Event/TicketProcessTransitions.pm
@@ -57,12 +57,6 @@ sub Run {
     # get ticket object
     my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
 
-    my $CacheKey = '_TicketProcessTransitions::AlreadyProcessed';
-
-    # loop protection: only execute this handler once for each ticket, as multiple events may be
-    #   fired, for example TicketTitleUpdate and TicketPriorityUpdate.
-    return if ( $TicketObject->{$CacheKey}->{ $Param{Data}->{TicketID} } );
-
     # get ticket data in silent mode, it could be that the ticket was deleted
     #   in the meantime.
     my %Ticket = $TicketObject->TicketGet(
@@ -71,14 +65,7 @@ sub Run {
         Silent        => 1,
     );
 
-    if ( !%Ticket ) {
-
-        # remember that the event was executed for this TicketID to avoid multiple executions.
-        #   Store the information on the ticketobject
-        $TicketObject->{$CacheKey}->{ $Param{Data}->{TicketID} } = 1;
-
-        return;
-    }
+    return if !%Ticket;
 
     # get config object
     my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
@@ -104,11 +91,17 @@ sub Run {
 
     # ok, now we know that we need to call the sequence flow logic for this ticket.
 
-    # Remember that the event was executed for this ticket to avoid multiple executions.
-    #   Store the information on the ticketobject, this needs to be done before the execution of the
-    #   transitions as it could happen that the transition generates new events that will be
-    #   processed in the mean time, before the chache is set, see bug#9748
-    $TicketObject->{$CacheKey}->{ $Param{Data}->{TicketID} } = 1;
+    # Loop protection: track visited activities per ticket, not just "was processed".
+    # This allows chained transitions (A→B→C) while preventing loops (A→B→A).
+    # See bug#9748 for original loop protection rationale.
+    my $CacheKey = '_TicketProcessTransitions::VisitedActivities';
+    $TicketObject->{$CacheKey}->{ $Param{Data}->{TicketID} } //= {};
+
+    # If we already visited this activity in this request, stop (actual loop detected).
+    return if $TicketObject->{$CacheKey}->{ $Param{Data}->{TicketID} }->{$ActivityEntityID};
+
+    # Mark current activity as visited before processing to prevent recursion.
+    $TicketObject->{$CacheKey}->{ $Param{Data}->{TicketID} }->{$ActivityEntityID} = 1;
 
     my $TransitionApplied = $ProcessObject->ProcessTransition(
         ProcessEntityID  => $ProcessEntityID,


### PR DESCRIPTION
<!--
  You are amazing! 🚀
  Thanks for contributing to the Znuny community project!
  Please, DO NOT DELETE ANY TEXT from this template (unless instructed)!

### Licensing, copyright and credits

Znuny is an open fork of an existing software. So we have to respect the already given copyright of the original creators.

New files will be licensed using the AGPL Version 3. If you contribute code to the Znuny project you will get mentioned in the pull request incl. the commit, in CHANGES.md and in AUTHORS.md. We will not mention you in the file you provided or changed. Your work is highly appreciated and acknowledged but you contribute it to the project and your copyright will pass on to the fork itself.
-->

## Proposed change

Enable automatic transition chaining in Process Management.

Currently, when a process ticket transitions from Activity A to Activity B, and the conditions for B→C are already met, the ticket stops at B. The user must reload the page for the next transition to be evaluated.

**Root cause:** The `TicketProcessTransitions` event handler uses a simple "already processed" flag per ticket, blocking all subsequent transition evaluations within the same request.

**Solution:** Replace the boolean flag with a visited-activities set. This allows chained transitions (A→B→C) while still preventing actual loops (A→B→A).

| Scenario | Before | After |
|----------|--------|-------|
| A→B→C chain | Stops at B | Continues to C |
| A→B→A loop | Stops at B | Stops at B (loop detected) |

## Type of change

`1 - 🚀 feature`

## Additional information

- Original loop protection (bug#9748) is preserved but refined
- No configuration changes required
- Backwards compatible

**Test process:** Import the attached [Export_PR_Transition_Chaining.yml](https://github.com/user-attachments/files/24915172/Export_PR_Transition_Chaining.yml) via Admin → Process Management. Create a process ticket, select any queue, set state to "closed successful", and submit. The ticket should progress directly to "Completed" without page refresh.

## Checklist

- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [ ] Local ZnunyCodePolicy passed.(❕)
- [ ] Local UnitTests / Selenium passed.(❕)
- [ ] GitHub workflow CI (UnitTests / Selenium) passed.(❗)

<!--
  Thank you for contributing ❤

  Znuny @znuny/znuny
-->
