### PR TITLE
Fixed: Navigation path for Ticket::Frontend::AgentTicketNoteToLinkedT…

### DIFF
--- a/Kernel/Config/Files/XML/Znuny.xml
+++ b/Kernel/Config/Files/XML/Znuny.xml
@@ -3109,7 +3109,7 @@
     </Setting>
     <Setting Name="Ticket::Frontend::AgentTicketNoteToLinkedTicket###IsVisibleForCustomerDefault" Required="0" Valid="1">
         <Description Translatable="1">Defines if the note in the NoteToLinkedTicket screen of the agent interface is visible for the customer by default.</Description>
-        <Navigation>Frontend::Agent::View::TicketNote</Navigation>
+        <Navigation>Frontend::Agent::View::TicketNoteToLinkedTicket</Navigation>
         <Value>
             <Item ValueType="Checkbox">0</Item>
         </Value>


### PR DESCRIPTION
## Proposed change

This PR fixes the navigation path of setting `Ticket::Frontend::AgentTicketNoteToLinkedTicket###IsVisibleForCustomerDefault` in navigation tree. It should be displayed together with similar settings.

All supported Znuny versions are affected. Please cherry-pick the changes into all supported branches.

## Type of change

- '1 - 🐞 bug 🐞'            - Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
  Put an 'x' in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  ❕ - nice to have
  ❗ - required before review
-->

- [X] The code change is tested and works locally.(❗)
- [X] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [X] Local ZnunyCodePolicy passed.(❕)
- [X] Local UnitTests / Selenium passed.(❕)
- [X] GitHub workflow CI (UnitTests / Selenium) passed.(❗)

<!--
  Thank you for contributing ❤

  Znuny @znuny/znuny
-->
