### PR TITLE
Allow Encrypted assertions in SAML Responses

### DIFF
--- a/Kernel/System/Auth/SAML.pm
+++ b/Kernel/System/Auth/SAML.pm
@@ -79,7 +79,7 @@ sub new {
     # Optional config options
     #
     for my $ConfigKey (
-        qw(RequestMetaDataURLSSLOptions RequestSignKey IdPCACert)
+        qw(RequestMetaDataURLSSLOptions RequestSignKey IdPCACert ResponseEncryptKey)
         )
     {
         $Self->{Config}->{$ConfigKey} = $ConfigObject->Get("$ConfigOptionPrefix$ConfigKey$Self->{Count}");

--- a/Kernel/System/Auth/SAML/Response.pm
+++ b/Kernel/System/Auth/SAML/Response.pm
@@ -18,6 +18,7 @@ our $ObjectManagerDisabled = 1;
 use Kernel::System::VariableCheck qw(:all);
 
 use Net::SAML2;
+use Net::SAML2::Object::Response;
 use MIME::Base64;
 use XML::LibXML;
 use XML::LibXML::XPathContext;

--- a/Kernel/System/Auth/SAML/Response.pm
+++ b/Kernel/System/Auth/SAML/Response.pm
@@ -107,11 +107,12 @@ sub DecodeResponse {
         xml => MIME::Base64::decode_base64($Param{Response}),
     );
 
-    if($nodes->size > 0){
+    if ( $nodes->size > 0 ) {
         $Self->{Assertion} = $Response->to_assertion (
             key_file => $Self->{Config}->{ResponseEncryptKey},
         );
-    }else{
+    }
+    else {
         $Self->{Assertion} = $Response->to_assertion ();
     }
 

--- a/Kernel/System/Auth/SAML/Response.pm
+++ b/Kernel/System/Auth/SAML/Response.pm
@@ -21,6 +21,7 @@ use Net::SAML2;
 use MIME::Base64;
 use XML::LibXML;
 use XML::LibXML::XPathContext;
+use URN::OASIS::SAML2 qw(URN_ASSERTION URN_PROTOCOL);
 
 =head1 PUBLIC INTERFACE
 
@@ -95,9 +96,24 @@ sub DecodeResponse {
     $Self->{XMLDOM} = $XMLParser->parse_string( $Self->{XMLString} );
     return if !$Self->{XMLDOM};
 
-    $Self->{Assertion} = Net::SAML2::Protocol::Assertion->new_from_xml(
-        xml => MIME::Base64::decode_base64( $Param{Response} ),
+    my $xpath = XML::LibXML::XPathContext->new($Self->{XMLDOM});
+    $xpath->registerNs('saml',  URN_ASSERTION);
+    $xpath->registerNs('samlp', URN_PROTOCOL);
+    
+    my $nodes = $xpath->findnodes('//saml:EncryptedAssertion');
+
+    my $Response = Net::SAML2::Object::Response->new_from_xml(
+        xml => MIME::Base64::decode_base64($Param{Response}),
     );
+
+    if($nodes->size > 0){
+        $Self->{Assertion} = $Response->to_assertion (
+            key_file => $Self->{Config}->{ResponseEncryptKey},
+        );
+    }else{
+        $Self->{Assertion} = $Response->to_assertion ();
+    }
+
     return if !$Self->{Assertion};
 
     $Self->{Decoded} = 1;
@@ -163,22 +179,23 @@ sub GetAttributeValues {
     # Note: $Self->{Assertion}->attributes() does not work here because it only
     # return the last one of attributes with the same name.
 
-    my $XPath = XML::LibXML::XPathContext->new( $Self->{XMLDOM} );
+    my $XPath = $Self->{Assertion}->{xpath};
     return if !$XPath;
 
     $XPath->registerNs(
         'samlp',
-        'urn:oasis:names:tc:SAML:2.0:protocol',
+        URN_PROTOCOL,
     );
 
     $XPath->registerNs(
         'saml',
-        'urn:oasis:names:tc:SAML:2.0:assertion',
+        URN_ASSERTION,
     );
 
-    my $Query = '/samlp:Response/saml:Assertion/saml:AttributeStatement/saml:Attribute[@Name="'
-        . $Name
-        . '"]/saml:AttributeValue';
+    my $Query = '//saml:Attribute[
+        @Name="' . $Name . '"
+        or @FriendlyName="' . $Name . '"
+        ]/saml:AttributeValue';
 
     my @Entries = $XPath->findnodes($Query);
     return if !@Entries;


### PR DESCRIPTION
<!--
  You are amazing! 🚀
  Thanks for contributing to the Znuny community project!
  Please, DO NOT DELETE ANY TEXT from this template (unless instructed)!

### Licensing, copyright and credits

Znuny is an open fork of an existing software. So we have to respect the already given copyright of the original creators.

New files will be licensed using the AGPL Version 3. If you contribute code to the Znuny project you will get mentioned in the pull request incl. the commit, in CHANGES.md and in AUTHORS.md. We will not mention you in the file you provided or changed. Your work is highly appreciated and acknowledged but you contribute it to the project and your copyright will pass on to the fork itself.
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why this pull request should be accepted. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The Proposed Change allows the IDP to send encrypted Assertions.

The DecodeResponse Funcion was altered to Identify a "EncryptedAssertion" Node.
If found the Assertion is loaded with the ResponseEncryptKey.

I also Introduced a new Query in GetAttributeValues because the old one was too strict an did not account for Friendlynames

## Type of change
<!--
  What type of change does your PR introduce to Znuny?
  NOTE: Please add only one label with a starting '1 - ' to this PR!
  If your PR requires multiple labels to be applied, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster for the code review.

- '1 - 🆙 dependency upgrade - Dependency upgrade (e.g. libraries)
- '1 - 🐞 bug 🐞'            - Bugfix (non-breaking change which fixes an issue)
- '1 - 💎 code quality'      - Code quality improvements to existing code or addition of unit tests
- '1 - 🚀 feature'           - New feature (which adds functionality to an existing integration)
- '1 - ...'

-->
 1 - 🚀 feature
## Additional information
<!--
  Details are important and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  Note: Remove this section if not needed.

  If a PR is related to an issue, please use the 'Linked issues' function on the sidebar.
-->

The Change Introduces a new Config variable "ResponseEncryptKey"

This is a path to a File wich holds the Private Encryption Key corredsponding to Encrypt KeyDescriptor of SP Metadata.

<!--
- This PR is related to PR: #
- ...
-->

## Checklist
<!--
  Put an 'x' in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  ❕ - nice to have
  ❗ - required before review
-->

- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [ ] Local ZnunyCodePolicy passed.(❕)
- [ ] Local UnitTests / Selenium passed.(❕)
- [ ] GitHub workflow CI (UnitTests / Selenium) passed.(❗)

<!--
  Thank you for contributing ❤

  Znuny @znuny/znuny
-->
