### PR TITLE
Fix misleading empty online repository state in package manager

### DIFF
--- a/Kernel/Language/de.pm
+++ b/Kernel/Language/de.pm
@@ -3961,6 +3961,8 @@ sub Data {
         'Repository List' => 'Verzeichnisliste',
         'No packages found in selected repository. Please check log for more info!' =>
             'Keine Pakete im gewählten Verzeichnis gefunden. Bitte prüfen Sie das Systemprotokoll für mehr Informationen!',
+        'All packages in this repository are already installed in the current version.' =>
+            'Alle Pakete in diesem Verzeichnis sind bereits in der aktuellen Version installiert.',
 
         # Perl Module: Kernel/Modules/AdminPostMasterFilter.pm
         'No such filter: %s' => 'Kein solcher Filter: %s',

--- a/Kernel/Modules/AdminPackageManager.pm
+++ b/Kernel/Modules/AdminPackageManager.pm
@@ -1535,19 +1535,37 @@ sub Run {
     );
     if ($Source) {
 
+        # Load once with same-version packages included so the controller can
+        # distinguish a real empty/error repository from a repository where all
+        # visible packages are already installed.
         my @List = $PackageObject->RepositoryPackageListGet(
-            Source => $Source,
-            Lang   => $LayoutObject->{UserLanguage},
+            Source             => $Source,
+            Lang               => $LayoutObject->{UserLanguage},
+            IncludeSameVersion => 1,
         );
-        if ( !@List ) {
+
+        my $RepositoryHasVisiblePackages = scalar @List;
+
+        @List = grep {
+            !( $_->{Installed} && !$_->{Upgrade} )
+        } @List;
+
+        if ( !@List && !$RepositoryHasVisiblePackages ) {
             $OutputNotify .= $LayoutObject->Notify(
                 Priority => 'Warning',
                 Info     => Translatable('No packages found in selected repository. Please check log for more info!'),
                 Link     => $LayoutObject->{Baselink} . 'Action=AdminLog',
             );
+        }
+
+        if ( !@List ) {
             $LayoutObject->Block(
                 Name => 'NoDataFoundMsg',
-                Data => {},
+                Data => {
+                    Message => $RepositoryHasVisiblePackages
+                        ? Translatable('All packages in this repository are already installed in the current version.')
+                        : '',
+                },
             );
         }
 

--- a/Kernel/Output/HTML/Templates/Standard/AdminPackageManager.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminPackageManager.tt
@@ -451,7 +451,11 @@
 [% RenderBlockStart("NoDataFoundMsg") %]
                             <tr>
                                 <td colspan="6">
+[% IF Data.Message %]
+                                    [% Translate(Data.Message) | html %]
+[% ELSE %]
                                     [% Translate("No data found.") | html %]
+[% END %]
                                 </td>
                             </tr>
 [% RenderBlockEnd("NoDataFoundMsg") %]


### PR DESCRIPTION
## Proposed change

The online repository view in the package manager can currently show a misleading warning when the selected repository is valid, reachable, and contains packages, but all visible packages are already installed in the same version.

In that situation, the controller treats the filtered online package list as if the repository were empty or broken and shows the warning:

No packages found in selected repository. Please check log for more info!

This is misleading, because there is no repository error. The repository is valid, but it currently offers no actionable package entries.

This change adjusts the package manager overview logic so it can distinguish between:

- a truly empty or broken repository
- a valid repository where all visible packages are already installed in the current version

The controller now loads the online repository list with same-version packages included, determines whether the repository contains visible packages at all, filters already installed same-version packages from the displayed list, and only shows the warning for a truly empty or broken repository.

If the repository is valid but all packages are already installed, the table now shows a specific informational message instead of the generic warning.

## Type of change

`1 - 🐞 bug 🐞`

## Additional information

- The change was tested on a running Znuny 7.3.3 system.
- Verified behavior:
  - an invalid or truly empty repository still shows the existing warning
  - a valid repository where all visible packages are already installed no longer shows the misleading warning
  - the online repository table now shows a specific informational empty-state message instead
- Local syntax validation passed for the changed Perl files.

## Checklist

- [x] The code change is tested and works locally.(❗)
- [x] There is no commented out code in this PR.(❕)
- [ ] You improved or added new unit tests.(❕)
- [ ] Local ZnunyCodePolicy passed.(❕)
- [ ] Local UnitTests / Selenium passed.(❕)
- [ ] GitHub workflow CI (UnitTests / Selenium) passed.(❗)