### PR TITLE
fix: Bug - Missing PID maintenace

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 # 7.3.7 2026-??-??
+ - 2026-08-21 Fixed: Orphaned process locks blocked mail queue sending and article index rebuild and were removed by unrelated Maint::Email::MailQueue actions. Thanks to @pboguslawski for reporting the issue. [#745](https://github.com/znuny/Znuny/issues/745)
  - 2026-08-20 Changed: Admin::Package::List now always reports package deployment status and warns about local modifications.
  - 2026-08-20 Fixed: Multiselect dynamic field values rendered without proper spacing in customer interface. Thanks to @LuBroering (Lukas Bröring Sector Nord AG) [PR#836](https://github.com/znuny/Znuny/pull/836).
  - 2026-08-20 Fixed: agent/customer re-direction after accepting initial information dialog (AgentInfo/CustomerAccept).

--- a/Kernel/System/Console/Command/Maint/Email/MailQueue.pm
+++ b/Kernel/System/Console/Command/Maint/Email/MailQueue.pm
@@ -122,24 +122,21 @@ sub PreRun {
         my $PIDObject = $Kernel::OM->Get('Kernel::System::PID');
         my $Force     = $Self->GetOption('force');
 
-        if ( !$Force ) {
-            my %PID = $PIDObject->PIDGet(
-                Name => 'MaintMailQueueSending',
-            );
-
-            if (%PID) {
-                die "Message sending already in progress! Skipping...\n";
-            }
-        }
-
         my $Success = $PIDObject->PIDCreate(
             Name  => 'MaintMailQueueSending',
             Force => $Force,
         );
 
         if ( !$Success ) {
+            my %PID = $PIDObject->PIDGet(
+                Name => 'MaintMailQueueSending',
+            );
+
+            die "Message sending already in progress! Skipping...\n" if %PID;
             die "Unable to register sending process! Skipping...\n";
         }
+
+        $Self->{SendingPIDCreated} = 1;
     }
 
     return;
@@ -391,17 +388,9 @@ sub _ValidateParams {
 sub PostRun {
     my ($Self) = @_;
 
-    my $PIDObject = $Kernel::OM->Get('Kernel::System::PID');
+    return 1 if !$Self->{SendingPIDCreated};
 
-    my %PID = $PIDObject->PIDGet(
-        Name => 'MaintMailQueueSending',
-    );
-
-    if (%PID) {
-        return $PIDObject->PIDDelete( Name => 'MaintMailQueueSending' );
-    }
-
-    return 1;
+    return $Kernel::OM->Get('Kernel::System::PID')->PIDDelete( Name => 'MaintMailQueueSending' );
 }
 
 1;

--- a/Kernel/System/Console/Command/Maint/Ticket/FulltextIndexRebuildWorker.pm
+++ b/Kernel/System/Console/Command/Maint/Ticket/FulltextIndexRebuildWorker.pm
@@ -69,23 +69,19 @@ sub PreRun {
 
     my $PIDObject = $Kernel::OM->Get('Kernel::System::PID');
 
-    my %PID = $PIDObject->PIDGet(
-        Name => 'ArticleSearchIndexRebuild',
-    );
-
-    if ( %PID && !$ForcePID ) {
-        die "Active indexing process already running! Skipping...\n";
-    }
-
     my $Success = $PIDObject->PIDCreate(
         Name  => 'ArticleSearchIndexRebuild',
-        Force => $Self->GetOption('force-pid'),
+        Force => $ForcePID,
     );
 
     if ( !$Success ) {
+        my %PID = $PIDObject->PIDGet(
+            Name => 'ArticleSearchIndexRebuild',
+        );
+
+        die "Active indexing process already running! Skipping...\n" if %PID;
         die "Unable to register indexing process! Skipping...\n";
     }
-
     return;
 }
 

--- a/Kernel/System/PID.pm
+++ b/Kernel/System/PID.pm
@@ -91,8 +91,11 @@ sub PIDCreate {
 
     if ( %ProcessID && !$Param{Force} ) {
 
-        my $TTL = $Param{TTL} || 3600;
-        if ( $ProcessID{Created} > ( time() - $TTL ) ) {
+        my $TTL         = $Param{TTL} || 3600;
+        my $TTLExceeded = $ProcessID{Created} <= ( time() - $TTL );
+        my $IsStale     = $Self->PIDIsStale( Name => $Param{Name} );
+
+        if ( !$TTLExceeded && !$IsStale ) {
             $Kernel::OM->Get('Kernel::System::Log')->Log(
                 Priority => 'notice',
                 Message  => "Can't create PID $ProcessID{Name}, because it's already running "
@@ -101,10 +104,14 @@ sub PIDCreate {
             return;
         }
 
+        my $RemoveReason = $IsStale
+            ? 'the process is not running anymore'
+            : "the TTL ($TTL sec) was exceeded";
+
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'notice',
             Message  =>
-                "Removed PID ($ProcessID{Name}/$ProcessID{Host}/$ProcessID{PID}, because the TTL ($TTL sec) was exceeded!",
+                "Removed PID ($ProcessID{Name}/$ProcessID{Host}/$ProcessID{PID}), because $RemoveReason!",
         );
     }
 
@@ -176,6 +183,43 @@ sub PIDGet {
     }
 
     return %Data;
+}
+
+=head2 PIDIsStale()
+
+checks if a process id lock is orphaned, which means that the process which registered
+the lock on this host is not running anymore. Locks which have been registered by another
+host cannot be checked and are therefore never reported as stale.
+
+    my $IsStale = $PIDObject->PIDIsStale(
+        Name => 'PostMasterPOP3',
+    );
+
+Returns 1 if the lock exists but its process is gone, 0 otherwise.
+
+=cut
+
+sub PIDIsStale {
+    my ( $Self, %Param ) = @_;
+
+    if ( !$Param{Name} ) {
+        $Kernel::OM->Get('Kernel::System::Log')->Log(
+            Priority => 'error',
+            Message  => 'Need Name'
+        );
+        return;
+    }
+
+    my %ProcessID = $Self->PIDGet( Name => $Param{Name} );
+
+    return 0 if !$ProcessID{PID};
+    return 0 if $ProcessID{Host} ne $Self->{Host};
+    return 0 if $ProcessID{PID} == $$;
+
+    return 0 if kill 0, $ProcessID{PID};
+    return 0 if !$!{ESRCH};
+
+    return 1;
 }
 
 =head2 PIDDelete()

--- a/scripts/test/PID.t
+++ b/scripts/test/PID.t
@@ -157,6 +157,82 @@ $Self->False(
     'PIDGet() for forced delete (PID should be deleted now)',
 );
 
+my $NonExistentPID = 65534;
+
+NONEXISTENTPID:
+while ( $NonExistentPID > 1 ) {
+    kill 0, $NonExistentPID;
+    last NONEXISTENTPID if $!{ESRCH};
+    $NonExistentPID--;
+}
+
+my $IsStale = $PIDObject->PIDIsStale( Name => 'Test' );
+$Self->False(
+    $IsStale,
+    'PIDIsStale() without existing PID',
+);
+
+my $PIDCreate4 = $PIDObject->PIDCreate( Name => 'Test' );
+$Self->True(
+    $PIDCreate4,
+    'PIDCreate4() for orphaned PID handling',
+);
+
+$IsStale = $PIDObject->PIDIsStale( Name => 'Test' );
+$Self->False(
+    $IsStale,
+    'PIDIsStale() for PID of the current process',
+);
+
+$UpdateSuccess = $Kernel::OM->Get('Kernel::System::DB')->Do(
+    SQL => '
+        UPDATE process_id
+        SET process_id = ?
+        WHERE process_name = ?',
+    Bind => [ \$NonExistentPID, \'Test' ],
+);
+$Self->True(
+    $UpdateSuccess,
+    'Updated PID to a process which is not running',
+);
+
+$IsStale = $PIDObject->PIDIsStale( Name => 'Test' );
+$Self->True(
+    $IsStale,
+    'PIDIsStale() for PID of a process which is not running',
+);
+
+my $PIDCreate5 = $PIDObject->PIDCreate( Name => 'Test' );
+$Self->True(
+    $PIDCreate5,
+    'PIDCreate5() must replace the orphaned PID',
+);
+
+%UpdatedPIDGet = $PIDObject->PIDGet( Name => 'Test' );
+$Self->Is(
+    $UpdatedPIDGet{PID},
+    $$,
+    'PIDGet() after replacing the orphaned PID',
+);
+
+$UpdateSuccess = $Kernel::OM->Get('Kernel::System::DB')->Do(
+    SQL => '
+        UPDATE process_id
+        SET process_id = ?, process_host = ?
+        WHERE process_name = ?',
+    Bind => [ \$NonExistentPID, \$RandomID, \'Test' ],
+);
+$Self->True(
+    $UpdateSuccess,
+    'Updated PID and host for stale check of another host',
+);
+
+$IsStale = $PIDObject->PIDIsStale( Name => 'Test' );
+$Self->False(
+    $IsStale,
+    'PIDIsStale() for PID of another host',
+);
+
 # cleanup is done by RestoreDatabase
 
 1;


### PR DESCRIPTION
Fixes #745

## Root cause

Orphaned process_id locks are never detected; MailQueue PostRun deletes locks it does not own

## Changes

- Added Kernel::System::PID::PIDIsStale() which reports locks whose registering process on the same host no longer exists (kill 0 / ESRCH, EPERM treated as alive, other hosts never reported stale) and used it in PIDCreate() so orphaned locks are removed and replaced instead of blocking. Maint::Email::MailQueue and Maint::Ticket::FulltextIndexRebuildWorker now rely on PIDCreate() instead of a plain PIDGet-and-die check, so stale/TTL handling applies; MailQueue PostRun only deletes the lock when this invocation actually created it. Added regression tests.